### PR TITLE
feat: add vitest

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -1,0 +1,100 @@
+# integration tests for vite and vitest
+name: vite-ecosystem-ci-vitest
+
+env:
+  # 7 GiB by default on GitHub, setting to 6 GiB
+  # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+  NODE_OPTIONS: --max-old-space-size=6144
+
+on:
+  schedule:
+    - cron: '0 5 * * 1,3,5' # monday,wednesday,friday 5AM
+  workflow_dispatch:
+    inputs:
+      vite_ref:
+        description: 'vite git ref'
+        required: true
+        type: string
+        default: 'main'
+      vite_skip_verify:
+        description: 'skip vite verification'
+        required: true
+        type: boolean
+        default: false
+      project_git_ref:
+        description: 'vitest git ref'
+        required: true
+        default: 'main'
+        type: string
+      project_skip_verify:
+        description: 'skip vitest verification'
+        required: true
+        type: boolean
+        default: false
+      project_skip_test:
+        description: 'skip vitest tests'
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  vitest:
+    timeout-minutes: 60
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node: [14]
+        os: [ubuntu-latest]
+    steps:
+      - name: 'print inputs'
+        run: echo inputs = '${{ toJSON(github.event.inputs) }}'
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm i -g pnpm@6
+      - name: 'checkout vite'
+        uses: actions/checkout@v2
+        with:
+          repository: 'vitejs/vite'
+          ref: '${{ github.event.inputs.vite_ref }}'
+          path: 'vite'
+      - name: 'install and build vite'
+        working-directory: 'vite'
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run ci-build-vite
+      - name: 'vite verification tests'
+        if: ${{ github.event.inputs.vite_skip_verify != 'true' }}
+        working-directory: 'vite'
+        run: |
+          pnpm run build-plugin-vue
+          pnpm run build-plugin-react
+          pnpm run test-serve -- --runInBand
+          pnpm run test-build -- --runInBand
+      - name: 'checkout vitest'
+        uses: actions/checkout@v2
+        with:
+          repository: 'vitest-dev/vitest'
+          ref: '${{ github.event.inputs.project_git_ref }}'
+          path: 'vitest'
+      - name: 'vitest verification tests'
+        if: ${{ github.event.inputs.project_skip_verify != 'true' }}
+        working-directory: 'vitest'
+        run: |
+          pnpm install --frozen-lockfile --prefer-offline
+          pnpm build
+          pnpm test:run
+      - name: 'link local vite to vitest and build'
+        working-directory: 'vitest'
+        run: |
+          git clean -fdx
+          mv package.json package.orig.json
+          jq -r '.devDependencies.vite="${{github.workspace}}/vite/packages/vite"|.pnpm.overrides.vite="${{github.workspace}}/vite/packages/vite"' package.orig.json > package.json
+          rm package.orig.json
+          pnpm install --prefer-frozen-lockfile --prefer-offline
+          pnpm build
+      - name: 'vitest integration tests'
+        if: ${{ github.event.inputs.project_skip_test != 'true' }}
+        working-directory: 'vitest'
+        run: |
+          pnpm test:run

--- a/vitest/.gitignore
+++ b/vitest/.gitignore
@@ -1,0 +1,2 @@
+vite
+vitest

--- a/vitest/integration-test.sh
+++ b/vitest/integration-test.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -e
+# this script requires git, pnpm and jq to be installed and in path
+
+VITE_REF='main'
+VITE_SKIP_VERIFY=0
+
+VITEST_REF='main'
+VITEST_SKIP_VERIFY=0
+VITEST_SKIP_TEST=0
+
+export NODE_OPTIONS="--max-old-space-size=6144"
+
+WORKSPACE=$PWD
+
+# setup repos
+if [ ! -d "vite" ]; then
+  git clone git@github.com:vitejs/vite.git vite
+fi
+if [ ! -d "vitest" ]; then
+  git clone git@github.com:vitest-dev/vitest vitest
+fi
+
+# VITE
+cd vite
+git clean -fdxq
+git pull origin "$VITE_REF"
+pnpm install --frozen-lockfile
+pnpm run ci-build-vite
+if [ "$VITE_SKIP_VERIFY" = "0" ]; then
+  echo "#### VERIFY VITE #####"
+  pnpm run build-plugin-vue
+  pnpm run build-plugin-react
+  pnpm run test-serve -- --runInBand
+  pnpm run test-build -- --runInBand
+fi
+
+# VITEST
+cd ../vitest
+git clean -fdxq
+git pull origin "$VITEST_REF"
+if [ "$VITEST_SKIP_VERIFY" = "0" ]; then
+  echo "#### VERIFY VITEST #####"
+  pnpm install --frozen-lockfile --prefer-offline
+  pnpm build
+  pnpm test:run
+fi
+echo "#### BUILD VITEST WITH LOCAL VITE #####"
+git clean -fdxq
+mv package.json package.orig.json
+jq -r ".devDependencies.vite=\"$WORKSPACE/vite/packages/vite\"|.pnpm.overrides.vite=\"$WORKSPACE/vite/packages/vite\"" package.orig.json > package.json
+rm package.orig.json
+pnpm install --prefer-frozen-lockfile --prefer-offline
+pnpm build
+if [ "$VITEST_SKIP_TEST" = "0" ]; then
+  echo "#### TEST VITEST WITH LOCAL VITE #####"
+  pnpm test:run
+fi


### PR DESCRIPTION
Adds Vitest running the basic core suite. We can't run the whole Vitest CI because it is currently checking a lot of projects, and at least locally it fails with vite-ruby. So this isn't a good test for Vitest itself. Core seems enough

@dominikg adding a new project was straightforward, but we should discuss later how to abstract some of the boilerplate. Maybe an action could be created at least for all pnpm projects

Maybe we could also have the vite repo at root instead of having to clone it in each of the folders for local testing