### PR TITLE
refactor: simplify runInRepo

### DIFF
--- a/svelte/index.js
+++ b/svelte/index.js
@@ -8,20 +8,18 @@ export async function test({ workspace }) {
   await runInRepo({
     repo: 'git@github.com:sveltejs/vite-plugin-svelte.git',
     folder: pluginPath,
+    build: 'build:ci',
+    test: 'test:ci',
     verify: true,
-    test: true,
-    buildTask: async() => $`pnpm build:ci`,
-    testTask: async() => $`pnpm test:ci`,
   })
 
   await runInRepo({
     repo: 'git@github.com:sveltejs/kit.git',
     ref: 'master',
     folder: resolve(workspace, 'kit'),
-    verify: true,
-    test: true,
     overrides: {"@sveltejs/vite-plugin-svelte":`${pluginPath}/packages/vite-plugin-svelte`},
-    buildTask: async() => $`pnpm build --filter ./packages --filter !./packages/create-svelte/templates`,
-    testTask: async() => $`pnpm test`,
+    build: 'build --filter ./packages --filter !./packages/create-svelte/templates',
+    test: 'test',
+    verify: true,
   })
 }

--- a/vitest/index.js
+++ b/vitest/index.js
@@ -1,4 +1,3 @@
-import { $ } from 'zx'
 import { resolve } from 'path'
 import { runInRepo } from '../utils.js'
 
@@ -6,9 +5,8 @@ export async function test({ workspace }) {
   await runInRepo({
     repo: 'git@github.com:vitest-dev/vitest',
     folder: resolve(workspace, 'vitest'),
+    build: 'build',
+    test: 'test:run',
     verify: true,
-    test: true,
-    buildTask: async() => $`pnpm build`,
-    testTask: async() => $`pnpm test:run`
   })
 }


### PR DESCRIPTION
I think this is compact enough now 😃 
```js
import { resolve } from 'path'
import { runInRepo } from '../utils.js'

export async function test({ workspace }) {
  await runInRepo({
    repo: 'git@github.com:vitest-dev/vitest',
    folder: resolve(workspace, 'vitest'),
    build: 'build',
    test: 'test:run',
    verify: true,
  })
}
```