### PR TITLE
feat: iles

### DIFF
--- a/iles/index.js
+++ b/iles/index.js
@@ -1,0 +1,12 @@
+import { runInRepo } from '../utils.js'
+
+export async function test({ workspace }) {
+  
+  await runInRepo({
+    repo: 'ElMassimo/iles',
+    build: 'build:all',
+    test: 'test',
+    verify: true,
+    workspace,
+  })
+}

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import { resolve } from 'path'
 import { setup, setupVite } from './utils.js'
 
-const suites = ['svelte', 'vitest']
+const suites = ['svelte', 'vitest', 'iles']
 
 // this script requires git, pnpm and jq to be installed and in path
 

--- a/utils.js
+++ b/utils.js
@@ -10,6 +10,7 @@ export let workspace
 export async function setup() {
   await $`set -e`
   await $`export NODE_OPTIONS="--max-old-space-size=6144"`
+  process.env.CI=true
   root = dirnameFrom(import.meta.url)
   workspace = path.resolve(root, 'workspace')
   vitePath = path.resolve(workspace, 'vite')


### PR DESCRIPTION
Adds [iles](https://github.com/ElMassimo/iles) to the Ecosystem CI

@ElMassimo, could you add a script that runs the iles CI without watch mode? Something like `test:ci` or `test:run`. You aren't seeing this issue because Vitest automatically disables watch mode in CI, but when we test this locally we still need it. We need to check why using `test run` as the script isn't working (maybe we should remove zx and use execa)

There are some failing tests, but I want to push this one so we can start playing. @ElMassimo, for reference, if you get this branch and run `nr test iles` it is going to clone vite, build latest, clone iles, build and verify that test are passing (here it fails now), then use pnpm overrides to set iles to use the local vite, and run the tests again. There will be an action that will report to a discord channel in Vite Land