### PR TITLE
feat: parallel jobs

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        project: [svelte, vitest, windicss]
+        project: [iles, svelte, vitest, windicss]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 16
       - run: npm i -g pnpm
       - run: pnpm i --frozen-lockfile
-      - run: node index.js # checkout, install and build vite
+      - run: node index.js --viteBuildOnly # checkout, install and build vite
       - name: pack vite
         shell: bash
         run: tar -czf vite.tar.gz --exclude="node_modules" vite

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -31,6 +31,7 @@ jobs:
           path: vite.tar.gz
           retention-days: 1
   test-ecosystem:
+    needs: build-vite
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -36,6 +36,7 @@ jobs:
     strategy:
       matrix:
         project: [svelte, vitest, windicss]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -1,0 +1,52 @@
+# integration tests for vite and svelte
+name: vite-ecosystem-ci-svelte
+
+env:
+  # 7 GiB by default on GitHub, setting to 6 GiB
+  # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+  NODE_OPTIONS: --max-old-space-size=6144
+
+on:
+  schedule:
+    - cron: '0 5 * * 1,3,5' # monday,wednesday,friday 5AM
+  workflow_dispatch:
+
+jobs:
+  build-vite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - run: npm i -g pnpm
+      - run: pnpm i --frozen-lockfile
+      - run: node index.js # checkout, install and build vite
+      - name: pack vite
+        shell: bash
+        run: tar -czf vite.tar.gz --exclude="node_modules" vite
+      - uses: actions/upload-artifact@v2
+        with:
+          name: vite-${{github.run_id}}
+          path: vite.tar.gz
+          retention-days: 1
+  test-ecosystem:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project: [svelte, vitest, windicss]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - run: npm i -g pnpm
+      - run: pnpm i --frozen-lockfile
+      - uses: actions/download-artifact@v2
+        with:
+          name: vite-${{github.run_id}}
+      - name: unpack vite
+        shell: bash
+        run: tar -xzf vite.tar.gz
+      - run: node index.js --skipViteBuild ${{ matrix.project }}
+

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -24,7 +24,7 @@ jobs:
       - run: node index.js --viteBuildOnly # checkout, install and build vite
       - name: pack vite
         shell: bash
-        run: tar -czf vite.tar.gz --exclude="node_modules" vite
+        run: tar -czf vite.tar.gz --exclude="node_modules" workspace/vite/
       - uses: actions/upload-artifact@v2
         with:
           name: vite-${{github.run_id}}

--- a/index.js
+++ b/index.js
@@ -1,15 +1,22 @@
 import { resolve } from 'path'
 import { setup, setupVite } from './utils.js'
 
-const suites = ['svelte', 'vitest', 'iles']
+const suites = [
+  'iles',
+  'svelte',
+  'vitest',
+  'windicss'
+]
 
-// this script requires git, pnpm and jq to be installed and in path
+// this script requires git and pnpm to be installed and in path
 
-const { suitesToRun } = parseArgs()
+const { suitesToRun, skipViteBuild } = parseArgs()
 
 const { root, vitePath, workspace } = await setup()
 
-await setupVite({ verify: false })
+if(!skipViteBuild) {
+  await setupVite({ verify: false })
+}
 
 for(const suite of suitesToRun) {
   await run(suite)
@@ -22,9 +29,13 @@ async function run(suite) {
 
 function parseArgs() {
   let suitesToRun = process.argv.slice(2);
+  const skipViteBuild = suitesToRun.includes('--skipViteBuild')
+  if(skipViteBuild){
+    suitesToRun = suitesToRun.filter(x => x !== '--skipViteBuild')
+  }
   if (!suitesToRun.length) {
     suitesToRun = suites
   }
-  return { suitesToRun }
+  return { suitesToRun, skipViteBuild }
 }
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function parseArgs() {
   }
   const skipViteBuild = args.includes('--skipViteBuild')
 
-  let suitesToRun = args.filter(x => x.startsWith('--'))
+  let suitesToRun = args.filter(x => x && !x.startsWith('--'))
   if(suitesToRun.length === 0) {
     suitesToRun = suites
   }

--- a/index.js
+++ b/index.js
@@ -17,10 +17,10 @@ const { root, vitePath, workspace } = await setup()
 if(!skipViteBuild) {
   await setupVite({ verify: false })
 }
-
 for(const suite of suitesToRun) {
   await run(suite)
 }
+
 
 async function run(suite) {
   const { test } = await import(`./${suite}/index.js`)
@@ -28,12 +28,15 @@ async function run(suite) {
 }
 
 function parseArgs() {
-  let suitesToRun = process.argv.slice(2);
-  const skipViteBuild = suitesToRun.includes('--skipViteBuild')
-  if(skipViteBuild){
-    suitesToRun = suitesToRun.filter(x => x !== '--skipViteBuild')
+  let args = process.argv.slice(2);
+  const viteBuildOnly = args.includes('--viteBuildOnly')
+  if(viteBuildOnly) {
+    return {suitesToRun: [], skipViteBuild: false}
   }
-  if (!suitesToRun.length) {
+  const skipViteBuild = args.includes('--skipViteBuild')
+
+  let suitesToRun = args.filter(x => x.startsWith('--'))
+  if(suitesToRun.length === 0) {
     suitesToRun = suites
   }
   return { suitesToRun, skipViteBuild }

--- a/utils.js
+++ b/utils.js
@@ -18,12 +18,16 @@ export async function setup() {
 }
 
 export async function setupRepo({ repo, dir, ref = 'main' }) {
+  if( !repo.includes(':') ) {
+    repo = `https://github.com/${repo}.git`
+  }
+
   if (! fs.existsSync(dir)) {
-    await $`git clone ${repo} ${dir}`
+    await $`git clone --depth=1 ${repo} ${dir}`
   }
   cd(dir)
   await $`git clean -fdxq`
-  await $`git pull origin "${ref}"`
+  await $`git pull --depth=1 origin "${ref}"`
 }
 
 function pnpmCommand(task) {
@@ -33,9 +37,7 @@ function pnpmCommand(task) {
 export async function runInRepo({ repo, workspace, folder, build, test, overrides, ref = 'main', verify = true }) {
   build = pnpmCommand(build)
   test = pnpmCommand(test)
-  if( !repo.includes(':') ) {
-    repo = `git@github.com:${repo}.git`
-  }
+
   if( !folder ) {
     // Use the repository name as the folder
     folder = repo.split('/')[1].slice(0,-4)
@@ -57,7 +59,7 @@ export async function runInRepo({ repo, workspace, folder, build, test, override
 }
 
 export async function setupVite({ verify = false } = {}) {
-  await setupRepo({ repo: 'git@github.com:vitejs/vite.git', dir: vitePath })
+  await setupRepo({ repo: 'vitejs/vite', dir: vitePath })
   await $`pnpm install --frozen-lockfile`
   await $`pnpm run ci-build-vite`
   await $`pnpm run build-plugin-vue`


### PR DESCRIPTION
setup a new ci job that uses a 2-stage build-test

stage 1: build vite and upload result
stage 2: matrix that downloads stage1 result and runs suites in parallel

some changes to support all this on github ci like switching to https, using shallow clones and additional script args