### PR TITLE
feat: bisect / fix: ci

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -28,27 +28,7 @@ on:
   repository_dispatch:
     types: [ecosystem-ci]
 jobs:
-  build-vite:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16
-      - run: npm i -g pnpm
-      - run: pnpm i --frozen-lockfile
-      - name: build branch
-        run: node ecosystem-ci.js build-vite --${{ github.event.inputs.refType || github.event.client_payload.refType || 'branch' }} ${{ github.event.inputs.ref || github.event.client_payload.ref || 'main' }}
-      - name: pack vite
-        shell: bash
-        run: tar -czf vite.tar.gz --exclude="node_modules" workspace/vite/
-      - uses: actions/upload-artifact@v2
-        with:
-          name: vite-${{github.run_id}}
-          path: vite.tar.gz
-          retention-days: 1
   test-ecosystem:
-    needs: build-vite
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -61,11 +41,5 @@ jobs:
           node-version: 16
       - run: npm i -g pnpm
       - run: pnpm i --frozen-lockfile
-      - uses: actions/download-artifact@v2
-        with:
-          name: vite-${{github.run_id}}
-      - name: unpack vite
-        shell: bash
-        run: tar -xzf vite.tar.gz
-      - run: node ecosystem-ci.js run-suites ${{ matrix.suite }}
+      - run: node ecosystem-ci.js --${{ github.event.inputs.refType || github.event.client_payload.refType || 'branch' }} ${{ github.event.inputs.ref || github.event.client_payload.ref || 'main' }} ${{ matrix.suite }}
 

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -11,11 +11,6 @@ on:
     - cron: '0 5 * * 1,3,5' # monday,wednesday,friday 5AM
   workflow_dispatch:
     inputs:
-      ref:
-        description: 'vite ref to use'
-        required: true
-        type: string
-        default: 'main'
       refType:
         description: 'type of ref'
         required: true
@@ -25,6 +20,11 @@ on:
           - tag
           - commit
         default: 'branch'
+      ref:
+        description: 'vite ref to use'
+        required: true
+        type: string
+        default: 'main'
   repository_dispatch:
     types: [ecosystem-ci]
 jobs:

--- a/ecosystem-ci.js
+++ b/ecosystem-ci.js
@@ -33,7 +33,7 @@ cli.command('build-vite', 'build vite only')
 
 cli.command('run-suites [...suites]', 'run single suite with pre-built vite')
 	.option('--verify', 'verify checkout by running tests before using local vite', {default: false})
-	.action(async (suites) => {
+	.action(async (suites, options) => {
 		const suitesToRun = getSuitesToRun(suites)
 		for (const suite of suitesToRun) {
 			await run(suite, options)

--- a/ecosystem-ci.js
+++ b/ecosystem-ci.js
@@ -2,21 +2,22 @@ import fs from 'fs'
 import path from 'path'
 import {cac} from 'cac'
 
-import {setup, setupVite} from './utils.js'
+import {setup, setupViteRepo, buildVite, bisectVite } from './utils.js'
 
 const {root, vitePath, workspace} = await setup()
 
 const cli = cac()
 cli.command('[...suites]', 'build vite and run selected suites')
-	.option('--verify', 'verify vite checkout by running tests', {default: false})
+	.option('--verify', 'verify checkouts by running tests', {default: false})
 	.option('--branch <branch>', 'vite branch to use', {default: 'main'})
 	.option('--tag <tag>', 'vite tag to use')
 	.option('--commit <commit>', 'vite commit sha to use')
 	.action(async (suites, options) => {
 		const suitesToRun = getSuitesToRun(suites)
-		await setupVite(options)
+		await setupViteRepo(options)
+		await buildVite({verify: options.verify})
 		for (const suite of suitesToRun) {
-			await run(suite)
+			await run(suite, options)
 		}
 	})
 
@@ -26,23 +27,57 @@ cli.command('build-vite', 'build vite only')
 	.option('--tag <tag>', 'vite tag to use')
 	.option('--commit <commit>', 'vite commit sha to use')
 	.action(async (options) => {
-		await setupVite(options)
+		await setupViteRepo(options)
+		await buildVite({verify: options.verify})
 	})
 
 cli.command('run-suites [...suites]', 'run single suite with pre-built vite')
+	.option('--verify', 'verify checkout by running tests before using local vite', {default: false})
 	.action(async (suites) => {
 		const suitesToRun = getSuitesToRun(suites)
 		for (const suite of suitesToRun) {
-			await run(suite)
+			await run(suite, options)
 		}
+	})
+
+cli.command('bisect [...suites]', 'use git bisect to find a commit in vite that broke suites')
+	.option('--good <ref>', 'last known good ref, e.g. a previous tag',{required: true})
+	.option('--verify', 'verify checkouts by running tests', {default: false})
+	.option('--branch <branch>', 'vite branch to use', {default: 'main'})
+	.option('--tag <tag>', 'vite tag to use')
+	.option('--commit <commit>', 'vite commit sha to use')
+	.action(async (suites, options) => {
+		const suitesToRun = getSuitesToRun(suites)
+		let isFirstRun = true;
+		const {verify} = options;
+		const runSuite = async () => {
+			try {
+				await buildVite({verify: isFirstRun && verify})
+				for (const suite of suitesToRun) {
+					await run(suite, {verify: isFirstRun && verify, skipGit: !isFirstRun})
+				}
+				isFirstRun = false;
+				return null
+			} catch (e) {
+				return e
+			}
+		}
+		await setupViteRepo({...options,shallow: false});
+		const initialError = await runSuite()
+		if(initialError) {
+			await bisectVite({good: options.good, runSuite})
+		} else {
+			console.log(`no errors for starting commit, cannot bisect`)
+		}
+
 	})
 cli.help()
 cli.parse()
 
 
-async function run(suite) {
+async function run(suite, {verify = true, skipGit = false}) {
 	const {test} = await import(`./tests/${suite}.js`)
-	await test({workspace: path.resolve(workspace, suite), root, vitePath})
+	await test({workspace: path.resolve(workspace, suite), root, vitePath, verify, skipGit})
 }
 
 function getSuitesToRun(suitesArg) {

--- a/tests/iles.js
+++ b/tests/iles.js
@@ -1,11 +1,12 @@
-import { runInRepo } from '../utils.js'
+import {runInRepo} from '../utils.js'
 
-export async function test({ workspace }) {
-  await runInRepo({
-    repo: 'ElMassimo/iles',
-    build: 'build:all',
-    test: 'test',
-    verify: true,
-    workspace,
-  })
+export async function test({workspace, verify = true, skipGit}) {
+	await runInRepo({
+		repo: 'ElMassimo/iles',
+		build: 'build:all',
+		test: 'test',
+		verify,
+		workspace,
+		skipGit
+	})
 }

--- a/tests/svelte.js
+++ b/tests/svelte.js
@@ -1,22 +1,24 @@
-import { runInRepo } from '../utils.js'
+import {runInRepo} from '../utils.js'
 
-export async function test({ workspace }) {
-  
-  const { dir: pluginPath } = await runInRepo({
-    repo: 'sveltejs/vite-plugin-svelte',
-    build: 'build:ci',
-    test: 'test:ci',
-    verify: true,
-    workspace,
-  })
+export async function test({workspace, verify = true, skipGit}) {
 
-  await runInRepo({
-    repo: 'sveltejs/kit',
-    ref: 'master',
-    overrides: {"@sveltejs/vite-plugin-svelte":`${pluginPath}/packages/vite-plugin-svelte`},
-    build: 'build --filter ./packages --filter !./packages/create-svelte/templates',
-    test: 'test',
-    verify: true,
-    workspace,
-  })
+	const {dir: pluginPath} = await runInRepo({
+		repo: 'sveltejs/vite-plugin-svelte',
+		build: 'build:ci',
+		test: 'test:ci',
+		verify,
+		workspace,
+		skipGit
+	})
+
+	await runInRepo({
+		repo: 'sveltejs/kit',
+		branch: 'master',
+		overrides: {"@sveltejs/vite-plugin-svelte": `${pluginPath}/packages/vite-plugin-svelte`},
+		build: 'build --filter ./packages --filter !./packages/create-svelte/templates',
+		test: 'test',
+		verify,
+		workspace,
+		skipGit
+	})
 }

--- a/tests/vitepress.js
+++ b/tests/vitepress.js
@@ -1,12 +1,13 @@
-import { runInRepo } from '../utils.js'
+import {runInRepo} from '../utils.js'
 
-export async function test({ workspace }) {
-  
-  await runInRepo({
-    repo: 'vuejs/vitepress',
-    build: 'build',
-    test: 'test',
-    verify: true,
-    workspace,
-  })
+export async function test({workspace, verify = true, skipGit}) {
+
+	await runInRepo({
+		repo: 'vuejs/vitepress',
+		build: 'build',
+		test: 'test',
+		verify,
+		workspace,
+		skipGit
+	})
 }

--- a/tests/vitest.js
+++ b/tests/vitest.js
@@ -1,12 +1,13 @@
-import { runInRepo } from '../utils.js'
+import {runInRepo} from '../utils.js'
 
-export async function test({ workspace }) {
-  
-  await runInRepo({
-    repo: 'vitest-dev/vitest',
-    build: 'build',
-    test: 'test:run',
-    verify: true,
-    workspace,
-  })
+export async function test({workspace, verify = true, skipGit}) {
+
+	await runInRepo({
+		repo: 'vitest-dev/vitest',
+		build: 'build',
+		test: 'test:run',
+		verify,
+		workspace,
+		skipGit
+	})
 }

--- a/tests/windicss.js
+++ b/tests/windicss.js
@@ -1,12 +1,13 @@
-import { runInRepo } from '../utils.js'
+import {runInRepo} from '../utils.js'
 
-export async function test({ workspace }) {
-  
-  await runInRepo({
-    repo: 'windicss/vite-plugin-windicss',
-    build: 'build',
-    test: 'test',
-    verify: true,
-    workspace,
-  })
+export async function test({workspace, verify = true, skipGit}) {
+
+	await runInRepo({
+		repo: 'windicss/vite-plugin-windicss',
+		build: 'build',
+		test: 'test',
+		verify,
+		workspace,
+		skipGit
+	})
 }

--- a/utils.js
+++ b/utils.js
@@ -139,6 +139,7 @@ export async function bisectVite({good, runSuite}) {
 				continue // see if next commit can be skipped too
 			}
 			const error = await runSuite()
+			cd(vitePath)
 			const bisectOut = await $`git bisect ${error ? 'bad' : 'good'}`
 			bisecting = bisectOut.substring(0, 10).toLowerCase() === 'bisecting:' // as long as git prints 'bisecting: ' there are more revisions to test
 		}
@@ -146,6 +147,7 @@ export async function bisectVite({good, runSuite}) {
 		console.log('error while bisecting',e);
 	} finally {
 		try {
+			cd(vitePath)
 			await $`git bisect reset`
 		} catch (e) {
 			console.log('Error while resetting bisect', e)


### PR DESCRIPTION
This PR contains a new command `node ecosystem-ci.js bisect` which automates bisecting a commit range with a set of suites.

It also changes the main ecosystem-ci.yml to not upload/download a pre-built vite, as this doesn't work reliably. Instead each job of the matrix builds vite itself