### PR TITLE
feat: add laravel suite

### DIFF
--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -33,6 +33,7 @@ on:
           - vitepress
           - vitest
           - windicss
+          - laravel
 jobs:
   execute-selected-suite:
     runs-on: ubuntu-latest

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        suite: [iles, svelte, vitepress, vitest, windicss]
+        suite: [iles, svelte, vitepress, vitest, windicss, laravel]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/tests/laravel.ts
+++ b/tests/laravel.ts
@@ -1,0 +1,11 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'innocenzi/laravel-vite',
+		build: 'build',
+		test: 'test:vite'
+	})
+}


### PR DESCRIPTION
This PR adds a suite for https://github.com/innocenzi/laravel-vite. 

It only runs the plugin tests, not all tests, because they require PHP too. But they don't depend on Vite itself so it's fine.

I've added `laravel` to both workflows, tell me if I'm missing something