### PR TITLE
fix: test scripts

### DIFF
--- a/tests/svelte.ts
+++ b/tests/svelte.ts
@@ -16,8 +16,7 @@ export async function test(options: RunOptions) {
 		overrides: {
 			'@sveltejs/vite-plugin-svelte': `${pluginPath}/packages/vite-plugin-svelte`
 		},
-		build:
-			'build --filter ./packages --filter !./packages/create-svelte/templates',
+		build: 'build',
 		test: 'test'
 	})
 }

--- a/tests/vitest.ts
+++ b/tests/vitest.ts
@@ -6,6 +6,6 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'vitest-dev/vitest',
 		build: 'build',
-		test: 'test:run -- --allowOnly'
+		test: 'test:run --allowOnly'
 	})
 }


### PR DESCRIPTION
for some reason the '--' in vitest is working when executing it from a local shell but not when it's run from inside ecosystem-ci.ts via execa. 