### PR TITLE
feat: add vite-plugin-ssr test suite, telefunc test suite, and a new option `beforeInstall`

### DIFF
--- a/tests/telefunc.ts
+++ b/tests/telefunc.ts
@@ -1,0 +1,12 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'vikejs/telefunc',
+		beforeInstall: 'setup', // Needed for submodule initialization
+		build: 'build',
+		test: 'test'
+	})
+}

--- a/tests/vite-plugin-ssr.ts
+++ b/tests/vite-plugin-ssr.ts
@@ -1,0 +1,12 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'brillout/vite-plugin-ssr',
+		beforeInstall: 'setup', // Needed for submodule initialization
+		build: 'build',
+		test: 'test'
+	})
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -15,6 +15,7 @@ export interface RunOptions {
 	release?: string
 	build?: Task
 	test?: Task | Task[]
+	beforeInstall?: Task
 }
 
 type Task = string | (() => Promise<any>)

--- a/utils.ts
+++ b/utils.ts
@@ -113,7 +113,18 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 	if (options.branch == null) {
 		options.branch = 'main'
 	}
-	const { build, test, repo, branch, tag, commit, skipGit, verify } = options
+	const {
+		build,
+		test,
+		repo,
+		branch,
+		tag,
+		commit,
+		skipGit,
+		verify,
+		beforeInstall
+	} = options
+	const beforeInstallCommand = toCommand(beforeInstall)
 	const buildCommand = toCommand(build)
 	const testCommand = toCommand(test)
 	const dir = path.resolve(
@@ -126,6 +137,8 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 	} else {
 		cd(dir)
 	}
+
+	await beforeInstallCommand?.()
 
 	if (verify && test) {
 		await $`ni --frozen`


### PR DESCRIPTION
The `pnpm run setup` step is needed to initialize the `libframe` Git submodule at https://github.com/brillout/vite-plugin-ssr and https://github.com/vikejs/telefunc.