### PR TITLE
feat: enable Hydrogen

### DIFF
--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -37,6 +37,7 @@ on:
           - laravel
           - nuxt-framework
           - marko
+          - hydrogen
 jobs:
   execute-selected-suite:
     runs-on: ubuntu-latest

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -42,7 +42,8 @@ jobs:
             windicss,
             laravel,
             nuxt-framework,
-            marko
+            marko,
+            hydrogen
           ]
       fail-fast: false
     steps:

--- a/tests/hydrogen.ts
+++ b/tests/hydrogen.ts
@@ -2,19 +2,10 @@ import { runInRepo } from '../utils'
 import { RunOptions } from '../types'
 
 export async function test(options: RunOptions) {
-	// Enable terminal colors for snapshot testing.
-	// https://nodejs.org/api/cli.html#environment-variables
-	const initialValue = process.env.FORCE_COLOR
-	process.env.FORCE_COLOR = 'true'
-
-	try {
-		await runInRepo({
-			...options,
-			repo: 'Shopify/hydrogen',
-			build: 'build',
-			test: 'test:vite-ci'
-		})
-	} finally {
-		process.env.FORCE_COLOR = initialValue
-	}
+	await runInRepo({
+		...options,
+		repo: 'Shopify/hydrogen',
+		build: 'build',
+		test: 'test:vite-ci'
+	})
 }

--- a/tests/hydrogen.ts
+++ b/tests/hydrogen.ts
@@ -4,12 +4,17 @@ import { RunOptions } from '../types'
 export async function test(options: RunOptions) {
 	// Enable terminal colors for snapshot testing.
 	// https://nodejs.org/api/cli.html#environment-variables
+	const initialValue = process.env.FORCE_COLOR
 	process.env.FORCE_COLOR = 'true'
 
-	await runInRepo({
-		...options,
-		repo: 'Shopify/hydrogen',
-		build: 'build',
-		test: 'test:vite-ci'
-	})
+	try {
+		await runInRepo({
+			...options,
+			repo: 'Shopify/hydrogen',
+			build: 'build',
+			test: 'test:vite-ci'
+		})
+	} finally {
+		process.env.FORCE_COLOR = initialValue
+	}
 }

--- a/tests/hydrogen.ts
+++ b/tests/hydrogen.ts
@@ -2,6 +2,10 @@ import { runInRepo } from '../utils'
 import { RunOptions } from '../types'
 
 export async function test(options: RunOptions) {
+	// Enable terminal colors for snapshot testing.
+	// https://nodejs.org/api/cli.html#environment-variables
+	process.env.FORCE_COLOR = 'true'
+
 	await runInRepo({
 		...options,
 		repo: 'Shopify/hydrogen',


### PR DESCRIPTION
The problem with Hydrogen unit tests was related to terminal color characters being removed, thus failing to match existing snapshots.

Should colors be enabled by default?