### PR TITLE
fix: master branch for vite-plugin-ssr and telefunc

### DIFF
--- a/tests/telefunc.ts
+++ b/tests/telefunc.ts
@@ -5,6 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'vikejs/telefunc',
+		branch: 'master',
 		beforeInstall: 'setup', // Needed for submodule initialization
 		build: 'build',
 		test: 'test'

--- a/tests/vite-plugin-ssr.ts
+++ b/tests/vite-plugin-ssr.ts
@@ -5,6 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'brillout/vite-plugin-ssr',
+		branch: 'master',
 		beforeInstall: 'setup', // Needed for submodule initialization
 		build: 'build',
 		test: 'test'


### PR DESCRIPTION
Both projects use `master` instead of `main`