### PR TITLE
feat: add astro

### DIFF
--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -39,6 +39,7 @@ on:
           - marko
           - vite-plugin-ssr
           - telefunc
+          - astro
 jobs:
   execute-selected-suite:
     runs-on: ubuntu-latest

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -44,7 +44,8 @@ jobs:
             nuxt-framework,
             marko,
             vite-plugin-ssr,
-            telefunc
+            telefunc,
+            astro
           ]
       fail-fast: false
     steps:

--- a/tests/astro.ts
+++ b/tests/astro.ts
@@ -1,0 +1,11 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'withastro/astro',
+		build: 'build',
+		test: 'test'
+	})
+}

--- a/tests/astro.ts
+++ b/tests/astro.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'withastro/astro',
-		build: 'build',
+		build: 'build:ci',
 		test: 'test'
 	})
 }


### PR DESCRIPTION
let's get this working now that astro is on pnpm :partying_face: 

`pnpm test astro --release 2.8.6` (uses vite release from npm)  fails on test step with
```shell
packages/webapi test:   1) Uncaught error outside test suite
packages/webapi test:   0 passing (335ms)
packages/webapi test:   1 failing
packages/webapi test:   1) Uncaught error outside test suite:
packages/webapi test:      Uncaught Workerpool Worker terminated Unexpectedly
packages/webapi test:     exitCode: `0`
packages/webapi test:     signalCode: `null`
packages/webapi test:     workerpool.script: `/home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/node_modules/.pnpm/mocha@9.2.0/node_modules/mocha/lib/nodejs/worker.js`
packages/webapi test:     spawnArgs: `/home/dominikg/.local/share/pnpm/nodejs/16.13.2/bin/node,/home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/node_modules/.pnpm/mocha@9.2.0/node_modules/mocha/lib/nodejs/worker.js`
packages/webapi test:     spawnfile: `/home/dominikg/.local/share/pnpm/nodejs/16.13.2/bin/node`
packages/webapi test:     stdout: `null`
packages/webapi test:     stderr: `null`
packages/webapi test:   Error: Workerpool Worker terminated Unexpectedly
packages/webapi test:       exitCode: `0`
packages/webapi test:       signalCode: `null`
packages/webapi test:       spawnfile: `/home/dominikg/.local/share/pnpm/nodejs/16.13.2/bin/node`
packages/webapi test:       stdout: `null`
packages/webapi test:       stderr: `null`
packages/webapi test:   
packages/webapi test:       at ChildProcess.<anonymous> (/home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/node_modules/.pnpm/workerpool@6.2.0/node_modules/workerpool/src/WorkerHandler.js:294:13)
packages/webapi test:       at ChildProcess.emit (node:events:390:28)
packages/webapi test:       at Process.ChildProcess._handle.onexit (node:internal/child_process:290:12)
packages/webapi test:   2) Uncaught error outside test suite
packages/webapi test:   3) Uncaught error outside test suite
packages/webapi test:   4) Uncaught error outside test suite
packages/webapi test:   5) Uncaught error outside test suite
packages/webapi test:   6) Uncaught error outside test suite
packages/webapi test:   7) Uncaught error outside test suite
packages/webapi test:   8) Uncaught error outside test suite
packages/webapi test:   9) Uncaught error outside test suite
packages/webapi test:   10) Uncaught error outside test suite
packages/webapi test:   11) Uncaught error outside test suite
packages/webapi test:   12) Uncaught error outside test suite
packages/webapi test: Failed
undefined
/home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/packages/webapi:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @astrojs/webapi@0.11.0 test: `mocha --parallel --timeout 15000`
Exit status 12
```

`pnpm test astro` (uses vite main branch built locally) fails on build with
```shell
astro:build: > astro@0.23.7 build /home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/packages/astro
astro:build: > astro-scripts build "src/**/*.ts" && tsc
astro:build: 
astro:build: src/core/build/scan-based-build.ts(43,23): error TS2742: The inferred type of 'build' cannot be named without a reference to '../../../../../../../vite/packages/vite/node_modules/rollup/dist/rollup'. This is likely not portable. A type annotation is necessary.
astro:build: src/vite-plugin-astro/index.ts(101,38): error TS2345: Argument of type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/vite/node_modules/.pnpm/rollup@2.62.0/node_modules/rollup/dist/rollup").PluginContext' is not assignable to parameter of type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/node_modules/.pnpm/rollup@2.66.0/node_modules/rollup/dist/rollup").PluginContext'.
astro:build:   The types returned by 'getModuleInfo(...)' are incompatible between these types.
astro:build:     Type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/vite/node_modules/.pnpm/rollup@2.62.0/node_modules/rollup/dist/rollup").ModuleInfo | null' is not assignable to type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/node_modules/.pnpm/rollup@2.66.0/node_modules/rollup/dist/rollup").ModuleInfo | null'.
astro:build:       Type 'ModuleInfo' is missing the following properties from type 'ModuleInfo': dynamicallyImportedIdResolutions, hasDefaultExport, importedIdResolutions
astro:build: src/vite-plugin-build-html/index.ts(70,9): error TS2322: Type '(this: MinimalPluginContext, inputOptions: InputOptions) => Promise<InputOptions>' is not assignable to type '(this: MinimalPluginContext, options: InputOptions) => InputOptions | Promise<InputOptions | null | undefined> | null | undefined'.
astro:build:   Type 'Promise<InputOptions>' is not assignable to type 'InputOptions | Promise<InputOptions | null | undefined> | null | undefined'.
astro:build:     Type 'Promise<InputOptions>' is not assignable to type 'Promise<InputOptions | null | undefined>'.
astro:build:       Type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/node_modules/.pnpm/rollup@2.66.0/node_modules/rollup/dist/rollup").InputOptions' is not assignable to type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/vite/node_modules/.pnpm/rollup@2.62.0/node_modules/rollup/dist/rollup").InputOptions'.
astro:build:         Types of property 'manualChunks' are incompatible.
astro:build:           Type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/node_modules/.pnpm/rollup@2.66.0/node_modules/rollup/dist/rollup").ManualChunksOption | undefined' is not assignable to type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/vite/node_modules/.pnpm/rollup@2.62.0/node_modules/rollup/dist/rollup").ManualChunksOption | undefined'.
astro:build:             Type 'GetManualChunk' is not assignable to type 'ManualChunksOption | undefined'.
astro:build:               Type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/node_modules/.pnpm/rollup@2.66.0/node_modules/rollup/dist/rollup").GetManualChunk' is not assignable to type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/vite/node_modules/.pnpm/rollup@2.62.0/node_modules/rollup/dist/rollup").GetManualChunk'.
astro:build:                 Types of parameters 'api' and 'api' are incompatible.
astro:build:                   Type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/vite/node_modules/.pnpm/rollup@2.62.0/node_modules/rollup/dist/rollup").GetManualChunkApi' is not assignable to type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/node_modules/.pnpm/rollup@2.66.0/node_modules/rollup/dist/rollup").GetManualChunkApi'.
astro:build:                     Types of property 'getModuleInfo' are incompatible.
astro:build:                       Type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/vite/node_modules/.pnpm/rollup@2.62.0/node_modules/rollup/dist/rollup").GetModuleInfo' is not assignable to type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/node_modules/.pnpm/rollup@2.66.0/node_modules/rollup/dist/rollup").GetModuleInfo'.
astro:build: src/vite-plugin-build-html/index.ts(196,38): error TS2345: Argument of type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/vite/node_modules/.pnpm/rollup@2.62.0/node_modules/rollup/dist/rollup").InputOptions' is not assignable to parameter of type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/node_modules/.pnpm/rollup@2.66.0/node_modules/rollup/dist/rollup").InputOptions'.
astro:build:   Types of property 'cache' are incompatible.
astro:build:     Type 'false | import("/home/dominikg/develop/vite-ecosystem-ci/workspace/vite/node_modules/.pnpm/rollup@2.62.0/node_modules/rollup/dist/rollup").RollupCache | undefined' is not assignable to type 'false | import("/home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/node_modules/.pnpm/rollup@2.66.0/node_modules/rollup/dist/rollup").RollupCache | undefined'.
astro:build:       Type 'RollupCache' is not assignable to type 'false | RollupCache | undefined'.
astro:build:         Type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/vite/node_modules/.pnpm/rollup@2.62.0/node_modules/rollup/dist/rollup").RollupCache' is not assignable to type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/node_modules/.pnpm/rollup@2.66.0/node_modules/rollup/dist/rollup").RollupCache'.
astro:build:           Types of property 'modules' are incompatible.
astro:build:             Type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/vite/node_modules/.pnpm/rollup@2.62.0/node_modules/rollup/dist/rollup").ModuleJSON[]' is not assignable to type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/node_modules/.pnpm/rollup@2.66.0/node_modules/rollup/dist/rollup").ModuleJSON[]'.
astro:build:               Type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/vite/node_modules/.pnpm/rollup@2.62.0/node_modules/rollup/dist/rollup").ModuleJSON' is not assignable to type 'import("/home/dominikg/develop/vite-ecosystem-ci/workspace/astro/astro/node_modules/.pnpm/rollup@2.66.0/node_modules/rollup/dist/rollup").ModuleJSON'.
astro:build:                 Types of property 'meta' are incompatible.
astro:build:                   Type 'CustomPluginOptions | null | undefined' is not assignable to type 'CustomPluginOptions'.
astro:build:                     Type 'undefined' is not assignable to type 'CustomPluginOptions'.
astro:build:  ELIFECYCLE  Command failed with exit code 1.
```

cc @natemoo-re
