### PR TITLE
ci: add timeout to test runs to prevent hanging runs for 6h

### DIFF
--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -42,6 +42,7 @@ on:
           - astro
 jobs:
   execute-selected-suite:
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -30,6 +30,7 @@ on:
     types: [ecosystem-ci]
 jobs:
   test-ecosystem:
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
20min, recent successful runs had <10min, double time should be plenty