### PR TITLE
fix: update to changes in vite package.json scripts

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -180,12 +180,9 @@ export async function setupViteRepo(options: Partial<RepoOptions>) {
 export async function buildVite({ verify = false }) {
 	cd(vitePath)
 	await $`ni --frozen`
-	await $`nr ci-build-vite`
-	await $`nr build-plugin-vue`
-	await $`nr build-plugin-react`
+	await $`nr build`
 	if (verify) {
-		await $`nr test-serve -- --runInBand`
-		await $`nr test-build -- --runInBand`
+		await $`nr test`
 	}
 }
 


### PR DESCRIPTION
this change means ecosystem-ci will no longer work for 2.9 series.  is that ok or should there a version switch?