### PR TITLE
Add storybook/builder-vite

### DIFF
--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -41,6 +41,7 @@ on:
           - telefunc
           - astro
           - rakkas
+          - storybook
 jobs:
   execute-selected-suite:
     timeout-minutes: 20

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -47,7 +47,8 @@ jobs:
             vite-plugin-ssr,
             telefunc,
             astro,
-            rakkas
+            rakkas,
+            storybook
           ]
       fail-fast: false
     steps:

--- a/tests/storybook.ts
+++ b/tests/storybook.ts
@@ -1,0 +1,11 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'storybookjs/builder-vite',
+		build: 'prepublish',
+		test: ['build-examples', 'test-ci']
+	})
+}

--- a/tests/storybook.ts
+++ b/tests/storybook.ts
@@ -5,6 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'storybookjs/builder-vite',
+		branch: 'vite-3',
 		build: 'prepublish',
 		test: ['build-examples', 'test-ci']
 	})


### PR DESCRIPTION
This passes locally when using `yarn test storybook --release 2.9.9`.