### PR TITLE
fix: use vite-plugin-ssr Vite 3 compatible branch

### DIFF
--- a/tests/vite-plugin-ssr.ts
+++ b/tests/vite-plugin-ssr.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'brillout/vite-plugin-ssr',
-		branch: 'master',
+		branch: '0.4.0',
 		beforeInstall: 'setup', // Needed for submodule initialization
 		build: 'build',
 		test: 'test'


### PR DESCRIPTION
The vite-plugin-ssr 0.4.0 branch's CI now works with both `2.9.10` and `3.0.0-alpha.9`.

For Vite 2, it needs to be `>=2.9.10` (because `configurePreviewServer()` is required).

For `3.0.0-alpha.9`, `@vitejs/react@2.0.0-alpha.2` needs to be used. I quickly checked and `vite-ecosystem-ci` seems to also override `@vitejs/react` but let me know if there is something I should do.

Also, the `0.4.0` branch uses pnpm v7.