### PR TITLE
chore: use inputs context

### DIFF
--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -56,4 +56,4 @@ jobs:
           deno-version: v1.19.3
       - run: corepack enable
       - run: pnpm i --frozen-lockfile
-      - run: pnpm tsx ecosystem-ci.ts --${{ github.event.inputs.refType }} ${{ github.event.inputs.ref }} ${{ github.event.inputs.suite }}
+      - run: pnpm tsx ecosystem-ci.ts --${{ inputs.refType }} ${{ inputs.ref }} ${{ inputs.suite }}

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -61,4 +61,4 @@ jobs:
           deno-version: v1.19.3
       - run: corepack enable
       - run: pnpm i --frozen-lockfile
-      - run: pnpm tsx ecosystem-ci.ts --${{ github.event.inputs.refType || github.event.client_payload.refType || 'branch' }} ${{ github.event.inputs.ref || github.event.client_payload.ref || 'main' }} ${{ matrix.suite }}
+      - run: pnpm tsx ecosystem-ci.ts --${{ inputs.refType || github.event.client_payload.refType || 'branch' }} ${{ inputs.ref || github.event.client_payload.ref || 'main' }} ${{ matrix.suite }}


### PR DESCRIPTION
Use the new `inputs` context from https://github.blog/changelog/2022-06-10-github-actions-inputs-unified-across-manual-and-reusable-workflows/

Don't think it would be deprecated ever, but the new syntax should be more searchable in github docs.