### PR TITLE
feat: astro vite-3 branch

### DIFF
--- a/tests/astro.ts
+++ b/tests/astro.ts
@@ -5,6 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'withastro/astro',
+		branch: 'vite-3',
 		build: 'build:ci',
 		test: 'test:vite-ci'
 	})


### PR DESCRIPTION
The Astro folks started a `vite-3` branch. It fails, but better to get it already hook up in vite-ecosystem-ci so we get a good picture of the state of the ecosystem

- https://github.com/withastro/astro/pull/3570