### PR TITLE
feat: add vite-setup-catalogue

### DIFF
--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -42,6 +42,7 @@ on:
           - astro
           - rakkas
           - storybook
+          - vite-setup-catalogue
 jobs:
   execute-selected-suite:
     timeout-minutes: 20

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -48,7 +48,8 @@ jobs:
             telefunc,
             astro,
             rakkas,
-            storybook
+            storybook,
+            vite-setup-catalogue
           ]
       fail-fast: false
     steps:

--- a/tests/vite-setup-catalogue.ts
+++ b/tests/vite-setup-catalogue.ts
@@ -6,6 +6,7 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'sapphi-red/vite-setup-catalogue',
 		branch: 'main',
-		test: 'test-for-ecosystem-ci'
+		test: 'test-for-ecosystem-ci',
+		useCopyForOverrides: true // needs copy because node_modules is mounted on docker container
 	})
 }

--- a/tests/vite-setup-catalogue.ts
+++ b/tests/vite-setup-catalogue.ts
@@ -1,0 +1,11 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'sapphi-red/vite-setup-catalogue',
+		branch: 'main',
+		test: 'test-for-ecosystem-ci'
+	})
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -16,6 +16,10 @@ export interface RunOptions {
 	build?: Task
 	test?: Task | Task[]
 	beforeInstall?: Task
+	/**
+	 * Whether to use `file:` instead of `link:`
+	 */
+	useCopyForOverrides?: boolean
 }
 
 type Task = string | (() => Promise<any>)

--- a/utils.ts
+++ b/utils.ts
@@ -122,7 +122,8 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 		commit,
 		skipGit,
 		verify,
-		beforeInstall
+		beforeInstall,
+		useCopyForOverrides
 	} = options
 	const beforeInstallCommand = toCommand(beforeInstall)
 	const buildCommand = toCommand(build)
@@ -155,19 +156,21 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 			overrides.vite = options.release
 		}
 	} else {
-		overrides.vite ||= `${options.vitePath}/packages/vite`
+		const protocol = useCopyForOverrides ? 'file:' : ''
+
+		overrides.vite ||= `${protocol}${options.vitePath}/packages/vite`
 		overrides[
 			`@vitejs/plugin-vue`
-		] ||= `${options.vitePath}/packages/plugin-vue`
+		] ||= `${protocol}${options.vitePath}/packages/plugin-vue`
 		overrides[
 			`@vitejs/plugin-vue-jsx`
-		] ||= `${options.vitePath}/packages/plugin-vue-jsx`
+		] ||= `${protocol}${options.vitePath}/packages/plugin-vue-jsx`
 		overrides[
 			`@vitejs/plugin-react`
-		] ||= `${options.vitePath}/packages/plugin-react`
+		] ||= `${protocol}${options.vitePath}/packages/plugin-react`
 		overrides[
 			`@vitejs/plugin-legacy`
-		] ||= `${options.vitePath}/packages/plugin-legacy`
+		] ||= `${protocol}${options.vitePath}/packages/plugin-legacy`
 	}
 	await applyPackageOverrides(dir, overrides)
 


### PR DESCRIPTION
Adds https://github.com/sapphi-red/vite-setup-catalogue which contains some minimal setup examples.

refs https://github.com/vitejs/vite/pull/8650
