### PR TITLE
fix: override `@type/node` to ensure consistent types

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -168,6 +168,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 		overrides[
 			`@vitejs/plugin-legacy`
 		] ||= `${options.vitePath}/packages/plugin-legacy`
+		overrides[`@types/node`] ||= `${options.vitePath}/node_modules/@types/node`
 	}
 	await applyPackageOverrides(dir, overrides)
 


### PR DESCRIPTION
`@types/node` is actually an implicit peer dependency of Vite.
So I overrode it with the version from the Vite project dependencies.

This fixes the most recent iles CI failure.