### PR TITLE
fix: override esbuild version in marko test

### DIFF
--- a/tests/marko.ts
+++ b/tests/marko.ts
@@ -7,6 +7,9 @@ export async function test(options: RunOptions) {
 		repo: 'marko-js/vite',
 		dir: 'marko', // default is last segment of repo, which would be vite and confusing
 		build: 'build',
-		test: 'mocha'
+		test: 'mocha',
+		overrides: {
+			esbuild: `${options.vitePath}/packages/vite/node_modules/esbuild`
+		}
 	})
 }


### PR DESCRIPTION
Marko installs esbuild in its repo, in parallel to vite.

But if the lockfile contains an esbuild version that isn't the same as
the one that Vite depends on, there might be type incompatibilities
when type-checking the `esbuildOptions` field in vite config.

This fixes the most recent Marko CI failure.
https://github.com/vitejs/vite-ecosystem-ci/runs/7087966647?check_suite_focus=true#step:7:291