### PR TITLE
fix: resolve realpaths of overrides that points to a package inside `node_modules`

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -171,9 +171,10 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 		overrides[
 			`@vitejs/plugin-legacy`
 		] ||= `${protocol}${options.vitePath}/packages/plugin-legacy`
-		overrides[
-			`@types/node`
-		] ||= `${protocol}${options.vitePath}/node_modules/@types/node`
+		const typesNodePath = fs.realpathSync(
+			`${options.vitePath}/node_modules/@types/node`
+		)
+		overrides[`@types/node`] ||= `${protocol}${typesNodePath}`
 	}
 	await applyPackageOverrides(dir, overrides)
 


### PR DESCRIPTION
Fixes the most recent Nuxt and Storybook CI failure.

It's because Yarn seems not to follow the symlinks created by PNPM.