### PR TITLE
Test storybook against main branch

### DIFF
--- a/tests/storybook.ts
+++ b/tests/storybook.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'storybookjs/builder-vite',
-		branch: 'vite-3',
+		branch: 'main',
 		build: 'prepublish',
 		test: ['build-examples', 'test-ci']
 	})


### PR DESCRIPTION
We've merged support for vite 3 into main and released a beta of @storybook/vite-builder: https://github.com/storybookjs/builder-vite/releases/tag/v0.2.0-beta.0

So, we can test against main now.