### PR TITLE
chore(rakkas): run a smaller subset of all tests

### DIFF
--- a/tests/rakkas.ts
+++ b/tests/rakkas.ts
@@ -7,6 +7,6 @@ export async function test(options: RunOptions) {
 		repo: 'rakkasjs/rakkasjs',
 		branch: 'next',
 		build: 'build',
-		test: 'ci'
+		test: 'vite-ecosystem-ci'
 	})
 }


### PR DESCRIPTION
I'm nearing a release so I've been adding a lot more tests that have little or no relation to Vite itself. This PR is for running a smaller subset of the Rakkas CI.