### PR TITLE
chore: move Astro ecosystem branch back to `main`

### DIFF
--- a/tests/astro.ts
+++ b/tests/astro.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'withastro/astro',
-		branch: 'vite-3',
+		branch: 'main',
 		build: 'build:ci',
 		test: 'test:vite-ci'
 	})


### PR DESCRIPTION
The Astro team just merged our Vite 3 upgrade. Time to test against main again 🥳 