### PR TITLE
chore: use same syntax for list

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -35,23 +35,21 @@ jobs:
     strategy:
       matrix:
         suite:
-          [
-            astro,
-            iles,
-            ladle,
-            laravel,
-            marko,
-            nuxt-framework,
-            rakkas,
-            storybook,
-            svelte,
-            telefunc,
-            vite-plugin-ssr,
-            vite-setup-catalogue,
-            vitepress,
-            vitest,
-            windicss
-          ]
+          - astro
+          - iles
+          - ladle
+          - laravel
+          - marko
+          - nuxt-framework
+          - rakkas
+          - storybook
+          - svelte
+          - telefunc
+          - vite-plugin-ssr
+          - vite-setup-catalogue
+          - vitepress
+          - vitest
+          - windicss
       fail-fast: false
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
`ecosystem-ci-selected.yml` uses `-` for list but `ecosystem-ci.yml` was using `[]` for list.
https://github.com/vitejs/vite-ecosystem-ci/blob/ae0d8e9ddb3f3efddbd50ff10b17457f5caed975/.github/workflows/ecosystem-ci-selected.yml#L27-L46

This PR changes `ecosystem-ci.yml` to use `-` to make user a bit easier to add a suite.
