### PR TITLE
fix: marko test command

### DIFF
--- a/tests/marko.ts
+++ b/tests/marko.ts
@@ -7,7 +7,7 @@ export async function test(options: RunOptions) {
 		repo: 'marko-js/vite',
 		dir: 'marko', // default is last segment of repo, which would be vite and confusing
 		build: 'build',
-		test: 'mocha',
+		test: 'test',
 		overrides: {
 			esbuild: `${options.vitePath}/packages/vite/node_modules/esbuild`
 		}


### PR DESCRIPTION
marko's Vite 3 support has landed (https://github.com/marko-js/vite/pull/21).

That PR removes `npm run mocha` and thus the test was failing.
https://github.com/marko-js/vite/pull/21/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L85-R89
This PR changes marko to use `npm run test` instead.

With this change marko passes 🎉 
https://github.com/sapphi-red/vite-ecosystem-ci/runs/7453521897?check_suite_focus=true
