### PR TITLE
fix: getPermanentRef for refType=tag

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -220,8 +220,13 @@ export async function setupViteRepo(options: Partial<RepoOptions>) {
 
 export async function getPermanentRef() {
 	cd(vitePath)
-	const ref = await $`git log -1 --pretty=format:%h`
-	return ref
+	try {
+		const ref = await $`git log -1 --pretty=format:%h`
+		return ref
+	} catch (e) {
+		console.warn(`Failed to obtain perm ref. ${e}`)
+		return undefined
+	}
 }
 
 export async function buildVite({ verify = false }) {

--- a/utils.ts
+++ b/utils.ts
@@ -220,7 +220,7 @@ export async function setupViteRepo(options: Partial<RepoOptions>) {
 
 export async function getPermanentRef() {
 	cd(vitePath)
-	const ref = await $`git show-ref --hash --abbrev HEAD`
+	const ref = await $`git log -1 --pretty=format:%h`
 	return ref
 }
 


### PR DESCRIPTION
`git show-ref --hash --abbrev HEAD` fails when `refType` is tag. I'm not sure why but it seems to be because of the detached head?
https://github.com/vitejs/vite-ecosystem-ci/runs/7487866389?check_suite_focus=true#step:8:15

I checked `git show-ref --hash --abbrev` works. But it returns multiple lines.

This PR uses `git log -1 --pretty=format:%h` instead. I tested this with https://github.com/vitejs/vite/commits/0b083ca8 too.
