### PR TITLE
chore: update ladle branch

### DIFF
--- a/tests/ladle.ts
+++ b/tests/ladle.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'tajo/ladle',
-		branch: 'master',
+		branch: 'main',
 		build: 'build',
 		beforeTest: 'pnpm playwright install chromium',
 		test: 'test'


### PR DESCRIPTION
Looks like https://github.com/tajo/ladle renamed default branch to `main`, which is failing CI.