### PR TITLE
fix: use v1.x for deno and continue if install fails

### DIFF
--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -55,8 +55,9 @@ jobs:
         id: setup-node
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.19.3
+          deno-version: v1.x
         id: setup-deno
+        continue-on-error: true
       - run: corepack enable
       - run: pnpm i --frozen-lockfile
       - run: pnpm tsx ecosystem-ci.ts --${{ inputs.refType }} ${{ inputs.ref }} ${{ inputs.suite }}

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -58,8 +58,9 @@ jobs:
         id: setup-node
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.19.3
+          deno-version: v1.x
         id: setup-deno
+        continue-on-error: true
       - run: corepack enable
       - run: pnpm i --frozen-lockfile
       - run: pnpm tsx ecosystem-ci.ts --${{ inputs.refType || github.event.client_payload.refType || 'branch' }} ${{ inputs.ref || github.event.client_payload.ref || 'main' }} ${{ matrix.suite }}


### PR DESCRIPTION
this should prevent deno install errors from messing up tests that do not require deno