### PR TITLE
feat: vite repo

### DIFF
--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -24,6 +24,11 @@ on:
         required: true
         type: string
         default: "main"
+      repo:
+        description: "vite repository to use"
+        required: true
+        type: string
+        default: "vitejs/vite"
       suite:
         description: "testsuite to run"
         required: true
@@ -60,7 +65,11 @@ jobs:
         continue-on-error: true
       - run: corepack enable
       - run: pnpm i --frozen-lockfile
-      - run: pnpm tsx ecosystem-ci.ts --${{ inputs.refType }} ${{ inputs.ref }} ${{ inputs.suite }}
+      - run: >-
+          pnpm tsx ecosystem-ci.ts
+          --${{ inputs.refType }} ${{ inputs.ref }}
+          --repo ${{ inputs.repo }}
+          ${{ inputs.suite }}
         id: ecosystem-ci-run
       - if: always()
         run: pnpm tsx discord-webhook.ts
@@ -68,6 +77,7 @@ jobs:
           WORKFLOW_NAME: ci-selected
           REF_TYPE: ${{ inputs.refType }}
           REF: ${{ inputs.ref }}
+          REPO: ${{ inputs.repo }}
           SUITE: ${{ inputs.suite }}
           STATUS: ${{ job.status }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -26,6 +26,11 @@ on:
         required: true
         type: string
         default: "main"
+      repo:
+        description: "vite repository to use"
+        required: true
+        type: string
+        default: "vitejs/vite"
   repository_dispatch:
     types: [ecosystem-ci]
 jobs:
@@ -63,7 +68,11 @@ jobs:
         continue-on-error: true
       - run: corepack enable
       - run: pnpm i --frozen-lockfile
-      - run: pnpm tsx ecosystem-ci.ts --${{ inputs.refType || github.event.client_payload.refType || 'branch' }} ${{ inputs.ref || github.event.client_payload.ref || 'main' }} ${{ matrix.suite }}
+      - run: >-
+          pnpm tsx ecosystem-ci.ts
+          --${{ inputs.refType || github.event.client_payload.refType || 'branch' }} ${{ inputs.ref || github.event.client_payload.ref || 'main' }}
+          --repo ${{ inputs.repo || github.event.client_payload.repo || 'vitejs/vite' }}
+          ${{ matrix.suite }}
         id: ecosystem-ci-run
       - if: always()
         run: pnpm tsx discord-webhook.ts
@@ -71,6 +80,7 @@ jobs:
           WORKFLOW_NAME: ci
           REF_TYPE: ${{ inputs.refType || github.event.client_payload.refType || 'branch' }}
           REF: ${{ inputs.ref || github.event.client_payload.ref || 'main' }}
+          REPO: ${{ inputs.repo || github.event.client_payload.repo || 'vitejs/vite' }}
           SUITE: ${{ matrix.suite }}
           STATUS: ${{ job.status }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/discord-webhook.ts
+++ b/discord-webhook.ts
@@ -136,14 +136,15 @@ function createTargetText(
 	permRef: string | undefined,
 	repo: string
 ) {
+	const repoText = repo !== 'vitejs/vite' ? `${repo}:` : ''
 	if (refType === 'branch') {
 		const link = `https://github.com/${repo}/commits/${permRef || ref}`
-		return `[${ref} (${permRef || 'unknown'})](${link})`
+		return `[${repoText}${ref} (${permRef || 'unknown'})](${link})`
 	}
 
 	const refTypeText = refType === 'release' ? ' (release)' : ''
 	const link = `https://github.com/${repo}/commits/${ref}`
-	return `[${ref}${refTypeText}](${link})`
+	return `[${repoText}${ref}${refTypeText}](${link})`
 }
 
 run().catch((e) => {

--- a/discord-webhook.ts
+++ b/discord-webhook.ts
@@ -7,6 +7,7 @@ type Env = {
 	WORKFLOW_NAME?: string
 	REF_TYPE?: RefType
 	REF?: string
+	REPO?: string
 	SUITE?: string
 	STATUS?: Status
 	DISCORD_WEBHOOK_URL?: string
@@ -43,6 +44,7 @@ async function run() {
 	assertEnv('WORKFLOW_NAME', env.WORKFLOW_NAME)
 	assertEnv('REF_TYPE', env.REF_TYPE)
 	assertEnv('REF', env.REF)
+	assertEnv('REPO', env.REPO)
 	assertEnv('SUITE', env.SUITE)
 	assertEnv('STATUS', env.STATUS)
 	assertEnv('DISCORD_WEBHOOK_URL', env.DISCORD_WEBHOOK_URL)
@@ -53,7 +55,7 @@ async function run() {
 	// vite repo is not cloned when release
 	const permRef = refType === 'release' ? undefined : await getPermanentRef()
 
-	const targetText = createTargetText(refType, env.REF, permRef)
+	const targetText = createTargetText(refType, env.REF, permRef, env.REPO)
 
 	const webhookContent = {
 		username: `vite-ecosystem-ci (${env.WORKFLOW_NAME})`,
@@ -131,15 +133,16 @@ async function createDescription(suite: string, targetText: string) {
 function createTargetText(
 	refType: RefType,
 	ref: string,
-	permRef: string | undefined
+	permRef: string | undefined,
+	repo: string
 ) {
 	if (refType === 'branch') {
-		const link = `https://github.com/vitejs/vite/commits/${permRef || ref}`
+		const link = `https://github.com/${repo}/commits/${permRef || ref}`
 		return `[${ref} (${permRef || 'unknown'})](${link})`
 	}
 
 	const refTypeText = refType === 'release' ? ' (release)' : ''
-	const link = `https://github.com/vitejs/vite/commits/${ref}`
+	const link = `https://github.com/${repo}/commits/${ref}`
 	return `[${ref}${refTypeText}](${link})`
 }
 

--- a/ecosystem-ci.ts
+++ b/ecosystem-ci.ts
@@ -10,6 +10,7 @@ const cli = cac()
 cli
 	.command('[...suites]', 'build vite and run selected suites')
 	.option('--verify', 'verify checkouts by running tests', { default: false })
+	.option('--repo <repo>', 'vite repository to use', { default: 'vitejs/vite' })
 	.option('--branch <branch>', 'vite branch to use', { default: 'main' })
 	.option('--tag <tag>', 'vite tag to use')
 	.option('--commit <commit>', 'vite commit sha to use')
@@ -39,6 +40,7 @@ cli
 	.option('--verify', 'verify vite checkout by running tests', {
 		default: false
 	})
+	.option('--repo <repo>', 'vite repository to use', { default: 'vitejs/vite' })
 	.option('--branch <branch>', 'vite branch to use', { default: 'main' })
 	.option('--tag <tag>', 'vite tag to use')
 	.option('--commit <commit>', 'vite commit sha to use')
@@ -55,6 +57,7 @@ cli
 		'verify checkout by running tests before using local vite',
 		{ default: false }
 	)
+	.option('--repo <repo>', 'vite repository to use', { default: 'vitejs/vite' })
 	.option('--release <version>', 'vite release to use from npm registry')
 	.action(async (suites, options: CommandOptions) => {
 		const { root, vitePath, workspace } = await setupEnvironment()
@@ -77,6 +80,7 @@ cli
 	)
 	.option('--good <ref>', 'last known good ref, e.g. a previous tag. REQUIRED!')
 	.option('--verify', 'verify checkouts by running tests', { default: false })
+	.option('--repo <repo>', 'vite repository to use', { default: 'vitejs/vite' })
 	.option('--branch <branch>', 'vite branch to use', { default: 'main' })
 	.option('--tag <tag>', 'vite tag to use')
 	.option('--commit <commit>', 'vite commit sha to use')

--- a/types.d.ts
+++ b/types.d.ts
@@ -28,6 +28,7 @@ type Task = string | (() => Promise<any>)
 
 export interface CommandOptions {
 	suites?: string[]
+	repo?: string
 	branch?: string
 	tag?: string
 	commit?: string

--- a/utils.ts
+++ b/utils.ts
@@ -241,7 +241,7 @@ export async function setupViteRepo(options: Partial<RepoOptions>) {
 		const rootPackageJson = JSON.parse(
 			await fs.promises.readFile(rootPackageJsonFile, 'utf-8')
 		)
-		if (rootPackageJson.name === 'vite-monorepo') {
+		if (rootPackageJson.name !== 'vite-monorepo') {
 			throw new Error('name does not match')
 		}
 	} catch (e) {

--- a/utils.ts
+++ b/utils.ts
@@ -235,6 +235,18 @@ export async function setupViteRepo(options: Partial<RepoOptions>) {
 		shallow: true,
 		...options
 	})
+
+	try {
+		const rootPackageJsonFile = path.join(vitePath, 'package.json')
+		const rootPackageJson = JSON.parse(
+			await fs.promises.readFile(rootPackageJsonFile, 'utf-8')
+		)
+		if (rootPackageJson.name === 'vite-monorepo') {
+			throw new Error('name does not match')
+		}
+	} catch (e) {
+		throw new Error(`Non-vite repository was cloned by setupViteRepo. (${e})`)
+	}
 }
 
 export async function getPermanentRef() {


### PR DESCRIPTION
This PR adds support for using repository other than vitejs/vite.

Example run: https://github.com/sapphi-red/vite-ecosystem-ci/runs/8059305521?check_suite_focus=true#step:7:11
![image](https://user-images.githubusercontent.com/49056869/187086946-7652ae62-7777-49f2-a0b8-33fc5f4bb363.png)

closes  #33
