### PR TITLE
fix: update vite-plugin-ssr integration

### DIFF
--- a/tests/vite-plugin-ssr.ts
+++ b/tests/vite-plugin-ssr.ts
@@ -6,7 +6,6 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'brillout/vite-plugin-ssr',
 		branch: 'main',
-		beforeInstall: 'setup', // Needed for submodule initialization
 		build: 'build',
 		test: 'test'
 	})


### PR DESCRIPTION
Vite-plugin-ssr's repository doesn't need the `setup` step anymore.