### PR TITLE
fix(svelte): install playwright chromium before testing 

### DIFF
--- a/tests/svelte.ts
+++ b/tests/svelte.ts
@@ -7,6 +7,7 @@ export async function test(options: RunOptions) {
 		repo: 'sveltejs/vite-plugin-svelte',
 		branch: 'main',
 		build: 'build:ci',
+		beforeTest: 'pnpm playwright install chromium',
 		test: 'test'
 	})
 


### PR DESCRIPTION
vite-plugin-svelte recently changed the way it uses playwright from platform browser to manual download