### PR TITLE
fix(svelte): override svelte as latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,10 @@
     "simple-git-hooks": "^2.8.1",
     "tsx": "^3.10.4",
     "typescript": "^4.8.4"
+  },
+  "pnpm": {
+    "overrides": {
+      "minimatch@<3.0.5": ">=3.0.5"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,8 @@
 lockfileVersion: 5.4
 
+overrides:
+  minimatch@<3.0.5: '>=3.0.5'
+
 specifiers:
   '@antfu/ni': ^0.18.2
   '@types/node': ^17.0.14

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,7 +745,7 @@ packages:
       eslint-plugin-es: 3.0.1_eslint@8.25.0
       eslint-utils: 2.1.0
       ignore: 5.2.0
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       resolve: 1.21.0
       semver: 6.3.0
     dev: true
@@ -1263,12 +1263,6 @@ packages:
   /mimic-fn/4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
-
-  /minimatch/3.0.4:
-    resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
-    dependencies:
-      brace-expansion: 1.1.11
-    dev: true
 
   /minimatch/3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}

--- a/tests/svelte.ts
+++ b/tests/svelte.ts
@@ -16,6 +16,7 @@ export async function test(options: RunOptions) {
 		repo: 'sveltejs/kit',
 		branch: 'master',
 		overrides: {
+			svelte: 'latest',
 			'@sveltejs/vite-plugin-svelte': `${pluginPath}/packages/vite-plugin-svelte`
 		},
 		build: 'build',

--- a/tests/svelte.ts
+++ b/tests/svelte.ts
@@ -6,6 +6,9 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'sveltejs/vite-plugin-svelte',
 		branch: 'main',
+		overrides: {
+			svelte: 'latest'
+		},
 		build: 'build:ci',
 		beforeTest: 'pnpm playwright install chromium',
 		test: 'test'


### PR DESCRIPTION
Attempt to fix failing svelte test, looks like `vite-plugin-svelte` and `svelte-kit` are using different versions of `svelte` causing errors. This PR ensures both are the same. [Discord discussion](https://discord.com/channels/804011606160703521/1030360762666979338/1032953953106788362).