### PR TITLE
[WIP] Allow tests to specify a 'packageDir', add storybook 7 tests

### DIFF
--- a/tests/storybook.ts
+++ b/tests/storybook.ts
@@ -6,7 +6,7 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'storybookjs/repro-templates-temp',
 		dir: 'storybook7',
-		packageDir: 'react-vite/default-js/after-storybook',
+		testSubdirectory: 'react-vite/default-js/after-storybook',
 		branch: 'next',
 		build: ['yarn install', 'build-storybook'],
 		test: [

--- a/tests/storybook.ts
+++ b/tests/storybook.ts
@@ -4,9 +4,14 @@ import { RunOptions } from '../types'
 export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
-		repo: 'storybookjs/builder-vite',
-		branch: 'main',
-		build: 'prepublish',
-		test: ['build-examples', 'test-ci'],
+		repo: 'storybookjs/repro-templates-temp',
+		dir: 'storybook7',
+		packageDir: 'react-vite/default-js/after-storybook',
+		branch: 'next',
+		build: ['yarn install', 'build-storybook'],
+		test: [
+			'yarn add --dev @storybook/test-runner http-server concurrently',
+			'npx concurrently -k "http-server storybook-static --port 6006 --silent" "npx wait-on http://localhost:6006 && npx test-storybook"',
+		],
 	})
 }

--- a/tests/storybook.ts
+++ b/tests/storybook.ts
@@ -8,7 +8,7 @@ export async function test(options: RunOptions) {
 		dir: 'storybook7',
 		testSubdirectory: 'react-vite/default-js/after-storybook',
 		branch: 'next',
-		build: ['yarn install', 'build-storybook'],
+		build: ['build-storybook'],
 		test: [
 			'yarn add --dev @storybook/test-runner http-server concurrently',
 			'npx concurrently -k "http-server storybook-static --port 6006 --silent" "npx wait-on http://localhost:6006 && npx test-storybook"',

--- a/types.d.ts
+++ b/types.d.ts
@@ -37,6 +37,7 @@ export interface CommandOptions {
 export interface RepoOptions {
 	repo: string
 	dir?: string
+	packageDir?: string
 	branch?: string
 	tag?: string
 	commit?: string

--- a/types.d.ts
+++ b/types.d.ts
@@ -37,7 +37,7 @@ export interface CommandOptions {
 export interface RepoOptions {
 	repo: string
 	dir?: string
-	packageDir?: string
+	testSubdirectory?: string
 	branch?: string
 	tag?: string
 	commit?: string

--- a/utils.ts
+++ b/utils.ts
@@ -8,7 +8,7 @@ import {
 	ProcessEnv,
 	RepoOptions,
 	RunOptions,
-	Task
+	Task,
 } from './types'
 //eslint-disable-next-line n/no-unpublished-import
 import { detect } from '@antfu/ni'
@@ -28,7 +28,7 @@ export async function $(literals: TemplateStringsArray, ...values: any[]) {
 	const cmd = literals.reduce(
 		(result, current, i) =>
 			result + current + (values?.[i] != null ? `${values[i]}` : ''),
-		''
+		'',
 	)
 
 	if (isGitHubActions) {
@@ -40,7 +40,7 @@ export async function $(literals: TemplateStringsArray, ...values: any[]) {
 	const proc = execaCommand(cmd, {
 		env,
 		stdio: 'pipe',
-		cwd
+		cwd,
 	})
 	proc.stdin && process.stdin.pipe(proc.stdin)
 	proc.stdout && proc.stdout.pipe(process.stdout)
@@ -65,7 +65,7 @@ export async function setupEnvironment(): Promise<EnvironmentData> {
 		CI: 'true',
 		TURBO_FORCE: 'true', // disable turbo caching, ecosystem-ci modifies things and we don't want replays
 		YARN_ENABLE_IMMUTABLE_INSTALLS: 'false', // to avoid errors with mutated lockfile due to overrides
-		NODE_OPTIONS: '--max-old-space-size=6144' // GITHUB CI has 7GB max, stay below
+		NODE_OPTIONS: '--max-old-space-size=6144', // GITHUB CI has 7GB max, stay below
 	}
 	return { root, workspace, vitePath, cwd, env }
 }
@@ -129,7 +129,7 @@ export async function setupRepo(options: RepoOptions) {
 }
 
 function toCommand(
-	task: Task | Task[] | void
+	task: Task | Task[] | void,
 ): ((scripts: any) => Promise<any>) | void {
 	return async (scripts: any) => {
 		const tasks = Array.isArray(task) ? task : [task]
@@ -143,7 +143,7 @@ function toCommand(
 				await task()
 			} else {
 				throw new Error(
-					`invalid task, expected string or function but got ${typeof task}: ${task}`
+					`invalid task, expected string or function but got ${typeof task}: ${task}`,
 				)
 			}
 		}
@@ -164,7 +164,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 		build,
 		test,
 		repo,
-		packageDir,
+		testSubdirectory,
 		branch,
 		tag,
 		commit,
@@ -172,7 +172,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 		verify,
 		beforeInstall,
 		beforeBuild,
-		beforeTest
+		beforeTest,
 	} = options
 	const beforeInstallCommand = toCommand(beforeInstall)
 	const beforeBuildCommand = toCommand(beforeBuild)
@@ -181,21 +181,21 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 	const testCommand = toCommand(test)
 	const dir = path.resolve(
 		options.workspace,
-		options.dir || repo.substring(repo.lastIndexOf('/') + 1)
+		options.dir || repo.substring(repo.lastIndexOf('/') + 1),
 	)
 
 	if (!skipGit) {
-		await setupRepo({ repo, dir, packageDir, branch, tag, commit })
+		await setupRepo({ repo, dir, testSubdirectory, branch, tag, commit })
 	} else {
-		if (packageDir) {
-			cd(path.join(dir, packageDir))
+		if (testSubdirectory) {
+			cd(path.join(dir, testSubdirectory))
 		} else {
 			cd(dir)
 		}
 	}
 
-	const pkgFile = packageDir
-		? path.join(dir, packageDir, 'package.json')
+	const pkgFile = testSubdirectory
+		? path.join(dir, testSubdirectory, 'package.json')
 		: path.join(dir, 'package.json')
 	const pkg = JSON.parse(await fs.promises.readFile(pkgFile, 'utf-8'))
 
@@ -212,7 +212,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 	if (options.release) {
 		if (overrides.vite && overrides.vite !== options.release) {
 			throw new Error(
-				`conflicting overrides.vite=${overrides.vite} and --release=${options.release} config. Use either one or the other`
+				`conflicting overrides.vite=${overrides.vite} and --release=${options.release} config. Use either one or the other`,
 			)
 		} else {
 			overrides.vite = options.release
@@ -236,7 +236,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 			// vite-3 dependency setup could have caused problems if we don't synchronize node versions
 			// vite-4 uses an optional peerDependency instead so keep project types
 			const typesNodePath = fs.realpathSync(
-				`${options.vitePath}/node_modules/@types/node`
+				`${options.vitePath}/node_modules/@types/node`,
 			)
 			overrides[`@types/node`] ||= `${typesNodePath}`
 		} else {
@@ -245,11 +245,11 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 			cd(dir) // buildOverrides changed dir, change it back
 			overrides = {
 				...overrides,
-				...localOverrides
+				...localOverrides,
 			}
 		}
 	}
-	await applyPackageOverrides(dir, pkg, overrides, packageDir)
+	await applyPackageOverrides(dir, pkg, overrides, testSubdirectory)
 	await beforeBuildCommand?.(pkg.scripts)
 	await buildCommand?.(pkg.scripts)
 	if (test) {
@@ -261,28 +261,28 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 
 export async function setupViteRepo(options: Partial<RepoOptions>) {
 	const repo = options.repo || 'vitejs/vite'
-	const { packageDir } = options
+	const { testSubdirectory } = options
 	await setupRepo({
 		repo,
 		dir: vitePath,
-		packageDir,
+		testSubdirectory,
 		branch: 'main',
 		shallow: true,
-		...options
+		...options,
 	})
 
 	try {
-		const rootPackageJsonFile = packageDir
-			? path.join(vitePath, packageDir, 'package.json')
+		const rootPackageJsonFile = testSubdirectory
+			? path.join(vitePath, testSubdirectory, 'package.json')
 			: path.join(vitePath, 'package.json')
 		const rootPackageJson = JSON.parse(
-			await fs.promises.readFile(rootPackageJsonFile, 'utf-8')
+			await fs.promises.readFile(rootPackageJsonFile, 'utf-8'),
 		)
 		const viteMonoRepoNames = ['@vitejs/vite-monorepo', 'vite-monorepo']
 		const { name } = rootPackageJson
 		if (!viteMonoRepoNames.includes(name)) {
 			throw new Error(
-				`expected  "name" field of ${repo}/package.json to indicate vite monorepo, but got ${name}.`
+				`expected  "name" field of ${repo}/package.json to indicate vite monorepo, but got ${name}.`,
 			)
 		}
 	} catch (e) {
@@ -312,7 +312,7 @@ export async function buildVite({ verify = false }) {
 
 export async function bisectVite(
 	good: string,
-	runSuite: () => Promise<Error | void>
+	runSuite: () => Promise<Error | void>,
 ) {
 	// sometimes vite build modifies files in git, e.g. LICENSE.md
 	// this would stop bisect, so to reset those changes
@@ -368,7 +368,7 @@ export async function applyPackageOverrides(
 	dir: string,
 	pkg: any,
 	overrides: Overrides = {},
-	packageDir?: string
+	testSubdirectory?: string,
 ) {
 	const useFileProtocol = (v: string) =>
 		isLocalOverride(v) ? `file:${path.resolve(v)}` : v
@@ -377,11 +377,11 @@ export async function applyPackageOverrides(
 		Object.entries(overrides)
 			//eslint-disable-next-line @typescript-eslint/no-unused-vars
 			.filter(([key, value]) => typeof value === 'string')
-			.map(([key, value]) => [key, useFileProtocol(value as string)])
+			.map(([key, value]) => [key, useFileProtocol(value as string)]),
 	)
 	await $`git clean -fdxq` // remove current install
-	if (packageDir) {
-		dir = path.join(dir, packageDir)
+	if (testSubdirectory) {
+		dir = path.join(dir, testSubdirectory)
 		cd(dir)
 	}
 
@@ -397,7 +397,7 @@ export async function applyPackageOverrides(
 		// avoid bug with absolute overrides in pnpm 7.18.0
 		if (version === '7.18.0') {
 			console.warn(
-				'detected pnpm@7.18.0, changing pkg.packageManager and pkg.engines.pnpm to enforce use of pnpm@7.18.1'
+				'detected pnpm@7.18.0, changing pkg.packageManager and pkg.engines.pnpm to enforce use of pnpm@7.18.1',
 			)
 			// corepack reads this and uses pnpm 7.18.1 then
 			pkg.packageManager = 'pnpm@7.18.1'
@@ -411,24 +411,24 @@ export async function applyPackageOverrides(
 		}
 		pkg.devDependencies = {
 			...pkg.devDependencies,
-			...overrides // overrides must be present in devDependencies or dependencies otherwise they may not work
+			...overrides, // overrides must be present in devDependencies or dependencies otherwise they may not work
 		}
 		if (!pkg.pnpm) {
 			pkg.pnpm = {}
 		}
 		pkg.pnpm.overrides = {
 			...pkg.pnpm.overrides,
-			...overrides
+			...overrides,
 		}
 	} else if (pm === 'yarn') {
 		pkg.resolutions = {
 			...pkg.resolutions,
-			...overrides
+			...overrides,
 		}
 	} else if (pm === 'npm') {
 		pkg.overrides = {
 			...pkg.overrides,
-			...overrides
+			...overrides,
 		}
 		// npm does not allow overriding direct dependencies, force it by updating the blocks themselves
 		for (const [name, version] of Object.entries(overrides)) {
@@ -462,7 +462,7 @@ export function dirnameFrom(url: string) {
 export function parseViteMajor(vitePath: string): number {
 	const content = fs.readFileSync(
 		path.join(vitePath, 'packages', 'vite', 'package.json'),
-		'utf-8'
+		'utf-8',
 	)
 	const pkg = JSON.parse(content)
 	return parseMajorVersion(pkg.version)
@@ -475,7 +475,7 @@ export function parseMajorVersion(version: string) {
 async function buildOverrides(
 	pkg: any,
 	options: RunOptions,
-	repoOverrides: Overrides
+	repoOverrides: Overrides,
 ) {
 	const { root } = options
 	const buildsPath = path.join(root, 'builds')
@@ -491,13 +491,13 @@ async function buildOverrides(
 	const deps = new Set([
 		...Object.keys(pkg.dependencies ?? {}),
 		...Object.keys(pkg.devDependencies ?? {}),
-		...Object.keys(pkg.peerDependencies ?? {})
+		...Object.keys(pkg.peerDependencies ?? {}),
 	])
 
 	const needsOverride = (p: string) =>
 		repoOverrides[p] === true || (deps.has(p) && repoOverrides[p] == null)
 	const buildsToRun = buildDefinitions.filter(({ packages }) =>
-		Object.keys(packages).some(needsOverride)
+		Object.keys(packages).some(needsOverride),
 	)
 	const overrides: Overrides = {}
 	for (const buildDef of buildsToRun) {
@@ -508,7 +508,7 @@ async function buildOverrides(
 			viteMajor: options.viteMajor,
 			skipGit: options.skipGit,
 			release: options.release,
-			verify: options.verify
+			verify: options.verify,
 			// do not pass along scripts
 		})
 		for (const [name, path] of Object.entries(buildDef.packages)) {

--- a/utils.ts
+++ b/utils.ts
@@ -8,7 +8,7 @@ import {
 	ProcessEnv,
 	RepoOptions,
 	RunOptions,
-	Task,
+	Task
 } from './types'
 //eslint-disable-next-line n/no-unpublished-import
 import { detect } from '@antfu/ni'
@@ -28,7 +28,7 @@ export async function $(literals: TemplateStringsArray, ...values: any[]) {
 	const cmd = literals.reduce(
 		(result, current, i) =>
 			result + current + (values?.[i] != null ? `${values[i]}` : ''),
-		'',
+		''
 	)
 
 	if (isGitHubActions) {
@@ -40,7 +40,7 @@ export async function $(literals: TemplateStringsArray, ...values: any[]) {
 	const proc = execaCommand(cmd, {
 		env,
 		stdio: 'pipe',
-		cwd,
+		cwd
 	})
 	proc.stdin && process.stdin.pipe(proc.stdin)
 	proc.stdout && proc.stdout.pipe(process.stdout)
@@ -65,7 +65,7 @@ export async function setupEnvironment(): Promise<EnvironmentData> {
 		CI: 'true',
 		TURBO_FORCE: 'true', // disable turbo caching, ecosystem-ci modifies things and we don't want replays
 		YARN_ENABLE_IMMUTABLE_INSTALLS: 'false', // to avoid errors with mutated lockfile due to overrides
-		NODE_OPTIONS: '--max-old-space-size=6144', // GITHUB CI has 7GB max, stay below
+		NODE_OPTIONS: '--max-old-space-size=6144' // GITHUB CI has 7GB max, stay below
 	}
 	return { root, workspace, vitePath, cwd, env }
 }
@@ -129,7 +129,7 @@ export async function setupRepo(options: RepoOptions) {
 }
 
 function toCommand(
-	task: Task | Task[] | void,
+	task: Task | Task[] | void
 ): ((scripts: any) => Promise<any>) | void {
 	return async (scripts: any) => {
 		const tasks = Array.isArray(task) ? task : [task]
@@ -143,7 +143,7 @@ function toCommand(
 				await task()
 			} else {
 				throw new Error(
-					`invalid task, expected string or function but got ${typeof task}: ${task}`,
+					`invalid task, expected string or function but got ${typeof task}: ${task}`
 				)
 			}
 		}
@@ -164,6 +164,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 		build,
 		test,
 		repo,
+		packageDir,
 		branch,
 		tag,
 		commit,
@@ -171,7 +172,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 		verify,
 		beforeInstall,
 		beforeBuild,
-		beforeTest,
+		beforeTest
 	} = options
 	const beforeInstallCommand = toCommand(beforeInstall)
 	const beforeBuildCommand = toCommand(beforeBuild)
@@ -180,16 +181,22 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 	const testCommand = toCommand(test)
 	const dir = path.resolve(
 		options.workspace,
-		options.dir || repo.substring(repo.lastIndexOf('/') + 1),
+		options.dir || repo.substring(repo.lastIndexOf('/') + 1)
 	)
 
 	if (!skipGit) {
-		await setupRepo({ repo, dir, branch, tag, commit })
+		await setupRepo({ repo, dir, packageDir, branch, tag, commit })
 	} else {
-		cd(dir)
+		if (packageDir) {
+			cd(path.join(dir, packageDir))
+		} else {
+			cd(dir)
+		}
 	}
 
-	const pkgFile = path.join(dir, 'package.json')
+	const pkgFile = packageDir
+		? path.join(dir, packageDir, 'package.json')
+		: path.join(dir, 'package.json')
 	const pkg = JSON.parse(await fs.promises.readFile(pkgFile, 'utf-8'))
 
 	await beforeInstallCommand?.(pkg.scripts)
@@ -205,7 +212,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 	if (options.release) {
 		if (overrides.vite && overrides.vite !== options.release) {
 			throw new Error(
-				`conflicting overrides.vite=${overrides.vite} and --release=${options.release} config. Use either one or the other`,
+				`conflicting overrides.vite=${overrides.vite} and --release=${options.release} config. Use either one or the other`
 			)
 		} else {
 			overrides.vite = options.release
@@ -229,7 +236,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 			// vite-3 dependency setup could have caused problems if we don't synchronize node versions
 			// vite-4 uses an optional peerDependency instead so keep project types
 			const typesNodePath = fs.realpathSync(
-				`${options.vitePath}/node_modules/@types/node`,
+				`${options.vitePath}/node_modules/@types/node`
 			)
 			overrides[`@types/node`] ||= `${typesNodePath}`
 		} else {
@@ -238,11 +245,11 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 			cd(dir) // buildOverrides changed dir, change it back
 			overrides = {
 				...overrides,
-				...localOverrides,
+				...localOverrides
 			}
 		}
 	}
-	await applyPackageOverrides(dir, pkg, overrides)
+	await applyPackageOverrides(dir, pkg, overrides, packageDir)
 	await beforeBuildCommand?.(pkg.scripts)
 	await buildCommand?.(pkg.scripts)
 	if (test) {
@@ -254,24 +261,28 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 
 export async function setupViteRepo(options: Partial<RepoOptions>) {
 	const repo = options.repo || 'vitejs/vite'
+	const { packageDir } = options
 	await setupRepo({
 		repo,
 		dir: vitePath,
+		packageDir,
 		branch: 'main',
 		shallow: true,
-		...options,
+		...options
 	})
 
 	try {
-		const rootPackageJsonFile = path.join(vitePath, 'package.json')
+		const rootPackageJsonFile = packageDir
+			? path.join(vitePath, packageDir, 'package.json')
+			: path.join(vitePath, 'package.json')
 		const rootPackageJson = JSON.parse(
-			await fs.promises.readFile(rootPackageJsonFile, 'utf-8'),
+			await fs.promises.readFile(rootPackageJsonFile, 'utf-8')
 		)
 		const viteMonoRepoNames = ['@vitejs/vite-monorepo', 'vite-monorepo']
 		const { name } = rootPackageJson
 		if (!viteMonoRepoNames.includes(name)) {
 			throw new Error(
-				`expected  "name" field of ${repo}/package.json to indicate vite monorepo, but got ${name}.`,
+				`expected  "name" field of ${repo}/package.json to indicate vite monorepo, but got ${name}.`
 			)
 		}
 	} catch (e) {
@@ -301,7 +312,7 @@ export async function buildVite({ verify = false }) {
 
 export async function bisectVite(
 	good: string,
-	runSuite: () => Promise<Error | void>,
+	runSuite: () => Promise<Error | void>
 ) {
 	// sometimes vite build modifies files in git, e.g. LICENSE.md
 	// this would stop bisect, so to reset those changes
@@ -357,6 +368,7 @@ export async function applyPackageOverrides(
 	dir: string,
 	pkg: any,
 	overrides: Overrides = {},
+	packageDir?: string
 ) {
 	const useFileProtocol = (v: string) =>
 		isLocalOverride(v) ? `file:${path.resolve(v)}` : v
@@ -365,9 +377,13 @@ export async function applyPackageOverrides(
 		Object.entries(overrides)
 			//eslint-disable-next-line @typescript-eslint/no-unused-vars
 			.filter(([key, value]) => typeof value === 'string')
-			.map(([key, value]) => [key, useFileProtocol(value as string)]),
+			.map(([key, value]) => [key, useFileProtocol(value as string)])
 	)
 	await $`git clean -fdxq` // remove current install
+	if (packageDir) {
+		dir = path.join(dir, packageDir)
+		cd(dir)
+	}
 
 	const agent = await detect({ cwd: dir, autoInstall: false })
 
@@ -381,7 +397,7 @@ export async function applyPackageOverrides(
 		// avoid bug with absolute overrides in pnpm 7.18.0
 		if (version === '7.18.0') {
 			console.warn(
-				'detected pnpm@7.18.0, changing pkg.packageManager and pkg.engines.pnpm to enforce use of pnpm@7.18.1',
+				'detected pnpm@7.18.0, changing pkg.packageManager and pkg.engines.pnpm to enforce use of pnpm@7.18.1'
 			)
 			// corepack reads this and uses pnpm 7.18.1 then
 			pkg.packageManager = 'pnpm@7.18.1'
@@ -395,24 +411,24 @@ export async function applyPackageOverrides(
 		}
 		pkg.devDependencies = {
 			...pkg.devDependencies,
-			...overrides, // overrides must be present in devDependencies or dependencies otherwise they may not work
+			...overrides // overrides must be present in devDependencies or dependencies otherwise they may not work
 		}
 		if (!pkg.pnpm) {
 			pkg.pnpm = {}
 		}
 		pkg.pnpm.overrides = {
 			...pkg.pnpm.overrides,
-			...overrides,
+			...overrides
 		}
 	} else if (pm === 'yarn') {
 		pkg.resolutions = {
 			...pkg.resolutions,
-			...overrides,
+			...overrides
 		}
 	} else if (pm === 'npm') {
 		pkg.overrides = {
 			...pkg.overrides,
-			...overrides,
+			...overrides
 		}
 		// npm does not allow overriding direct dependencies, force it by updating the blocks themselves
 		for (const [name, version] of Object.entries(overrides)) {
@@ -446,7 +462,7 @@ export function dirnameFrom(url: string) {
 export function parseViteMajor(vitePath: string): number {
 	const content = fs.readFileSync(
 		path.join(vitePath, 'packages', 'vite', 'package.json'),
-		'utf-8',
+		'utf-8'
 	)
 	const pkg = JSON.parse(content)
 	return parseMajorVersion(pkg.version)
@@ -459,7 +475,7 @@ export function parseMajorVersion(version: string) {
 async function buildOverrides(
 	pkg: any,
 	options: RunOptions,
-	repoOverrides: Overrides,
+	repoOverrides: Overrides
 ) {
 	const { root } = options
 	const buildsPath = path.join(root, 'builds')
@@ -475,13 +491,13 @@ async function buildOverrides(
 	const deps = new Set([
 		...Object.keys(pkg.dependencies ?? {}),
 		...Object.keys(pkg.devDependencies ?? {}),
-		...Object.keys(pkg.peerDependencies ?? {}),
+		...Object.keys(pkg.peerDependencies ?? {})
 	])
 
 	const needsOverride = (p: string) =>
 		repoOverrides[p] === true || (deps.has(p) && repoOverrides[p] == null)
 	const buildsToRun = buildDefinitions.filter(({ packages }) =>
-		Object.keys(packages).some(needsOverride),
+		Object.keys(packages).some(needsOverride)
 	)
 	const overrides: Overrides = {}
 	for (const buildDef of buildsToRun) {
@@ -492,7 +508,7 @@ async function buildOverrides(
 			viteMajor: options.viteMajor,
 			skipGit: options.skipGit,
 			release: options.release,
-			verify: options.verify,
+			verify: options.verify
 			// do not pass along scripts
 		})
 		for (const [name, path] of Object.entries(buildDef.packages)) {


### PR DESCRIPTION
This is an attempt to get storybook back into vite-ecosystem-ci.  For now, this just adds storybook 7, though 6.5 could likely be added as well.

In order to do so, I had to add support for specifying a directory containing a `package.json` file, other than the repo root.  I did this by adding a `packageDir` parameter to test option objects.

This checks out storybook's repro repository, which contains the latest storybook versions and bootstrapped projects with various frameworks, all regenerated nightly to make sure the latest versions are used.

For now, I've just added a test for storybook and react, though theoretically others could be used as well I think.

I can't get this to pass locally, but I'm not sure what's going on.  The `node_modules/vite/node_modules` in my project seems to be full of broken symlinks.  

I'm opening this up as a WIP to see what happens in CI, and potentially get feedback from @dominikg whether this seems like a decent approach in the first place.