### PR TITLE
feat: run lint and check scripts in svelte repos

### DIFF
--- a/tests/svelte.ts
+++ b/tests/svelte.ts
@@ -9,9 +9,9 @@ export async function test(options: RunOptions) {
 		overrides: {
 			svelte: 'latest'
 		},
-		build: 'build:ci',
+		build: 'build',
 		beforeTest: 'pnpm playwright install chromium',
-		test: 'test'
+		test: ['lint','test']
 	})
 
 	await runInRepo({
@@ -24,6 +24,6 @@ export async function test(options: RunOptions) {
 		},
 		build: 'build',
 		beforeTest: 'pnpm playwright install',
-		test: 'test'
+		test: ['lint','check','test']
 	})
 }


### PR DESCRIPTION
This would have caught https://github.com/vitejs/vite/issues/10656  

The additional runtime is only a few seconds.
Switched from build:ci to build in v-p-s because sveltekit check does depend on types of v-p-s too.
