### PR TITLE
chore: switch to eslint-plugin-n

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,7 +5,7 @@ module.exports = defineConfig({
 	root: true,
 	extends: [
 		'eslint:recommended',
-		'plugin:node/recommended',
+		'plugin:n/recommended',
 		'plugin:@typescript-eslint/recommended'
 	],
 	parser: '@typescript-eslint/parser',
@@ -25,7 +25,8 @@ module.exports = defineConfig({
 				destructuring: 'all'
 			}
 		],
-		'node/no-missing-import': 'off', // doesn't like ts imports
+		'n/no-missing-import': 'off', // doesn't like ts imports
+		'n/no-process-exit': 'off',
 		'@typescript-eslint/no-explicit-any': 'off' // we use any in some places
 	}
 })

--- a/ecosystem-ci.ts
+++ b/ecosystem-ci.ts
@@ -125,7 +125,6 @@ cli.help()
 cli.parse()
 
 async function run(suite: string, options: RunOptions) {
-	// eslint-disable-next-line node/no-unsupported-features/es-syntax
 	const { test } = await import(`./tests/${suite}.ts`)
 	await test({
 		...options,

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "packageManager": "pnpm@7.14.0",
   "type": "module",
   "engines": {
-    "node": "^14.13.1 || ^16 || ^18",
+    "node": "^14.14.0 || ^16 || ^18",
     "pnpm": "^7.14.0"
   },
   "repository": {
@@ -50,16 +50,11 @@
     "@typescript-eslint/parser": "^5.40.1",
     "eslint": "^8.26.0",
     "eslint-define-config": "^1.8.0",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-n": "^15.4.0",
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",
     "simple-git-hooks": "^2.8.1",
     "tsx": "^3.11.0",
     "typescript": "^4.8.4"
-  },
-  "pnpm": {
-    "overrides": {
-      "minimatch@<3.0.5": ">=3.0.5"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,5 @@
 lockfileVersion: 5.4
 
-overrides:
-  minimatch@<3.0.5: '>=3.0.5'
-
 specifiers:
   '@antfu/ni': ^0.18.2
   '@types/node': ^17.0.14
@@ -11,7 +8,7 @@ specifiers:
   cac: ^6.7.14
   eslint: ^8.26.0
   eslint-define-config: ^1.8.0
-  eslint-plugin-node: ^11.1.0
+  eslint-plugin-n: ^15.4.0
   execa: ^6.1.0
   lint-staged: ^13.0.3
   node-fetch: ^3.2.10
@@ -32,7 +29,7 @@ devDependencies:
   '@typescript-eslint/parser': 5.40.1_wyqvi574yv7oiwfeinomdzmc3m
   eslint: 8.26.0
   eslint-define-config: 1.8.0
-  eslint-plugin-node: 11.1.0_eslint@8.26.0
+  eslint-plugin-n: 15.4.0_eslint@8.26.0
   lint-staged: 13.0.3
   prettier: 2.7.1
   simple-git-hooks: 2.8.1
@@ -377,6 +374,12 @@ packages:
 
   /buffer-from/1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: true
+
+  /builtins/5.0.1:
+    resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
+    dependencies:
+      semver: 7.3.7
     dev: true
 
   /cac/6.7.14:
@@ -724,8 +727,8 @@ packages:
     engines: {node: '>= 14.6.0', npm: '>= 6.0.0', pnpm: '>= 7.0.0'}
     dev: true
 
-  /eslint-plugin-es/3.0.1_eslint@8.26.0:
-    resolution: {integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==}
+  /eslint-plugin-es/4.1.0_eslint@8.26.0:
+    resolution: {integrity: sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=4.19.1'
@@ -735,19 +738,21 @@ packages:
       regexpp: 3.2.0
     dev: true
 
-  /eslint-plugin-node/11.1.0_eslint@8.26.0:
-    resolution: {integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==}
-    engines: {node: '>=8.10.0'}
+  /eslint-plugin-n/15.4.0_eslint@8.26.0:
+    resolution: {integrity: sha512-MkoKy9/lfd52TAXK4fkABgCp0aglk82Q3viy2UOWIEpTVE/Cem5P/UAxMBA4vSw7Gy+2egPqImE9euitLGp5aw==}
+    engines: {node: '>=12.22.0'}
     peerDependencies:
-      eslint: '>=5.16.0'
+      eslint: '>=7.0.0'
     dependencies:
+      builtins: 5.0.1
       eslint: 8.26.0
-      eslint-plugin-es: 3.0.1_eslint@8.26.0
-      eslint-utils: 2.1.0
+      eslint-plugin-es: 4.1.0_eslint@8.26.0
+      eslint-utils: 3.0.0_eslint@8.26.0
       ignore: 5.2.0
+      is-core-module: 2.11.0
       minimatch: 3.1.2
-      resolve: 1.21.0
-      semver: 6.3.0
+      resolve: 1.22.1
+      semver: 7.3.7
     dev: true
 
   /eslint-scope/5.1.1:
@@ -1098,8 +1103,8 @@ packages:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
     dev: true
 
-  /is-core-module/2.8.1:
-    resolution: {integrity: sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==}
+  /is-core-module/2.11.0:
+    resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
     dependencies:
       has: 1.0.3
     dev: true
@@ -1440,11 +1445,11 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /resolve/1.21.0:
-    resolution: {integrity: sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==}
+  /resolve/1.22.1:
+    resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
     hasBin: true
     dependencies:
-      is-core-module: 2.8.1
+      is-core-module: 2.11.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
@@ -1483,11 +1488,6 @@ packages:
     resolution: {integrity: sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==}
     dependencies:
       tslib: 2.3.1
-    dev: true
-
-  /semver/6.3.0:
-    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
-    hasBin: true
     dev: true
 
   /semver/7.3.7:

--- a/utils.ts
+++ b/utils.ts
@@ -10,7 +10,7 @@ import {
 	RunOptions,
 	Task
 } from './types'
-//eslint-disable-next-line node/no-unpublished-import
+//eslint-disable-next-line n/no-unpublished-import
 import { detect } from '@antfu/ni'
 
 let vitePath: string


### PR DESCRIPTION
Switched to `eslint-plugin-n` that is a maintained fork of `eslint-plugin-node`. (`eslint-plugin-node` was depending on the vulnerable `minimatch`)

This PR will fix the audit CI fail in #139.
