### PR TITLE
fix: remove build script for sveltekit 

### DIFF
--- a/tests/svelte.ts
+++ b/tests/svelte.ts
@@ -20,9 +20,9 @@ export async function test(options: RunOptions) {
 		branch: 'master',
 		overrides: {
 			svelte: 'latest',
-			'@sveltejs/vite-plugin-svelte': `${pluginPath}/packages/vite-plugin-svelte`
+			'@sveltejs/vite-plugin-svelte': `${pluginPath}/packages/vite-plugin-svelte`,
+			'@types/node':'^16.11.68' // override to kit's version to prevent ecosystem-ci override with vite version
 		},
-		build: 'build',
 		beforeTest: 'pnpm playwright install',
 		test: ['lint','check','test']
 	})


### PR DESCRIPTION
and prevent vite types/node override causing a mismatch

sveltekit isn't using a build step internally for a while now and a recent PR removed the root build script from it's package.json so we no longer need to call it here.

the override for types/node is needed to avoid an error when calling `check`. Vite currently uses @types/node@17, which is incompatible to kit and causing a check error in a test file that uses webcrypto.subtle 
see https://discord.com/channels/804011606160703521/1036513246288556062/1036561228010639380 and https://github.com/vitejs/vite-ecosystem-ci/actions/runs/3358813763/jobs/5566222879#step:7:1328