### PR TITLE
feat: vite major option

### DIFF
--- a/ecosystem-ci.ts
+++ b/ecosystem-ci.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import process from 'process'
 import { cac } from 'cac'
 
-import { setupEnvironment, setupViteRepo, buildVite, bisectVite } from './utils'
+import {setupEnvironment, setupViteRepo, buildVite, bisectVite, parseMajorFromPkg, parseMajorVersion} from './utils'
 import { CommandOptions, RunOptions } from './types'
 
 const cli = cac()
@@ -18,13 +18,18 @@ cli
 	.action(async (suites, options: CommandOptions) => {
 		const { root, vitePath, workspace } = await setupEnvironment()
 		const suitesToRun = getSuitesToRun(suites, root)
+		let viteMajor;
 		if (!options.release) {
 			await setupViteRepo(options)
 			await buildVite({ verify: options.verify })
+			viteMajor = parseMajorFromPkg(vitePath);
+		} else {
+			viteMajor = parseMajorVersion(options.release)
 		}
 		const runOptions: RunOptions = {
 			root,
 			vitePath,
+			viteMajor,
 			workspace,
 			release: options.release,
 			verify: options.verify,
@@ -66,6 +71,7 @@ cli
 			...options,
 			root,
 			vitePath,
+			viteMajor: parseMajorFromPkg(vitePath),
 			workspace
 		}
 		for (const suite of suitesToRun) {
@@ -104,6 +110,7 @@ cli
 						skipGit: !isFirstRun,
 						root,
 						vitePath,
+						viteMajor: parseMajorFromPkg(vitePath),
 						workspace
 					})
 				}

--- a/ecosystem-ci.ts
+++ b/ecosystem-ci.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import process from 'process'
 import { cac } from 'cac'
 
-import {setupEnvironment, setupViteRepo, buildVite, bisectVite, parseMajorFromPkg, parseMajorVersion} from './utils'
+import {setupEnvironment, setupViteRepo, buildVite, bisectVite, parseViteMajor, parseMajorVersion} from './utils'
 import { CommandOptions, RunOptions } from './types'
 
 const cli = cac()
@@ -22,7 +22,7 @@ cli
 		if (!options.release) {
 			await setupViteRepo(options)
 			await buildVite({ verify: options.verify })
-			viteMajor = parseMajorFromPkg(vitePath);
+			viteMajor = parseViteMajor(vitePath);
 		} else {
 			viteMajor = parseMajorVersion(options.release)
 		}
@@ -71,7 +71,7 @@ cli
 			...options,
 			root,
 			vitePath,
-			viteMajor: parseMajorFromPkg(vitePath),
+			viteMajor: parseViteMajor(vitePath),
 			workspace
 		}
 		for (const suite of suitesToRun) {
@@ -110,7 +110,7 @@ cli
 						skipGit: !isFirstRun,
 						root,
 						vitePath,
-						viteMajor: parseMajorFromPkg(vitePath),
+						viteMajor: parseViteMajor(vitePath),
 						workspace
 					})
 				}

--- a/tests/svelte.ts
+++ b/tests/svelte.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	const { dir: pluginPath } = await runInRepo({
 		...options,
 		repo: 'sveltejs/vite-plugin-svelte',
-		branch: 'vite-4',
+		branch: options.viteMajor === 4 ? 'vite-4' : 'main',
 		overrides: {
 			svelte: 'latest'
 		},
@@ -17,7 +17,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'sveltejs/kit',
-		branch: 'vite-4',
+		branch: options.viteMajor === 4 ? 'vite-4' : 'master',
 		overrides: {
 			svelte: 'latest',
 			'@sveltejs/vite-plugin-svelte': `${pluginPath}/packages/vite-plugin-svelte`,

--- a/tests/vitepress.ts
+++ b/tests/vitepress.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'vuejs/vitepress',
-		branch: 'vite-4',
+		branch: options.viteMajor === 4 ? 'vite-4' : 'main',
 		build: 'build',
 		test: 'test'
 	})

--- a/types.d.ts
+++ b/types.d.ts
@@ -10,6 +10,7 @@ export interface RunOptions {
 	workspace: string
 	root: string
 	vitePath: string
+	viteMajor: number
 	verify?: boolean
 	skipGit?: boolean
 	release?: string

--- a/utils.ts
+++ b/utils.ts
@@ -384,3 +384,11 @@ export async function applyPackageOverrides(
 export function dirnameFrom(url: string) {
 	return path.dirname(fileURLToPath(url))
 }
+
+export function parseMajorFromPkg(pkgDir: string):number {
+	return parseMajorVersion(JSON.parse(fs.readFileSync(path.join(pkgDir,'package.json'),'utf-8')).version);
+}
+
+export function parseMajorVersion(version: string) {
+	return parseInt(version.split('.',1)[0],10)
+}

--- a/utils.ts
+++ b/utils.ts
@@ -385,8 +385,10 @@ export function dirnameFrom(url: string) {
 	return path.dirname(fileURLToPath(url))
 }
 
-export function parseMajorFromPkg(pkgDir: string):number {
-	return parseMajorVersion(JSON.parse(fs.readFileSync(path.join(pkgDir,'package.json'),'utf-8')).version);
+export function parseViteMajor(vitePath: string):number {
+	const content = fs.readFileSync(path.join(vitePath,'packages','vite','package.json'),'utf-8')
+	const pkg = JSON.parse(content);
+	return parseMajorVersion(pkg.version);
 }
 
 export function parseMajorVersion(version: string) {


### PR DESCRIPTION
pass `viteMajor` in runOptions for tests to be able to switch to a different branch that supports this major version