### PR TITLE
fix: use correct suite names for svelte tests

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -113,8 +113,9 @@ jobs:
           - nuxt-framework
           - rakkas
 #          - storybook  # disabled until test is updated, see https://github.com/vitejs/vite-ecosystem-ci/issues/130
-          - svelte
+          - sveltekit
           - vite-plugin-ssr
+          - vite-plugin-svelte
           - vite-setup-catalogue
           - vitepress
           - vitest


### PR DESCRIPTION
 in runs triggered by PR comments from vite repo