### PR TITLE
Remove `@types/node` overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   },
   "devDependencies": {
     "@antfu/ni": "^0.18.8",
-    "@types/node": "^17.0.14",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
     "eslint": "^8.28.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,7 +3,6 @@ lockfileVersion: 5.4
 specifiers:
   '@actions/core': ^1.10.0
   '@antfu/ni': ^0.18.8
-  '@types/node': ^17.0.14
   '@typescript-eslint/eslint-plugin': ^5.45.0
   '@typescript-eslint/parser': ^5.45.0
   cac: ^6.7.14
@@ -26,7 +25,6 @@ dependencies:
 
 devDependencies:
   '@antfu/ni': 0.18.8
-  '@types/node': 17.0.14
   '@typescript-eslint/eslint-plugin': 5.45.0_czs5uoqkd3podpy6vgtsxfc7au
   '@typescript-eslint/parser': 5.45.0_hsf322ms6xhhd4b5ne6lb74y4a
   eslint: 8.28.0
@@ -157,10 +155,6 @@ packages:
 
   /@types/json-schema/7.0.9:
     resolution: {integrity: sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==}
-    dev: true
-
-  /@types/node/17.0.14:
-    resolution: {integrity: sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==}
     dev: true
 
   /@types/semver/7.3.13:

--- a/tests/sveltekit.ts
+++ b/tests/sveltekit.ts
@@ -19,10 +19,9 @@ export async function test(options: RunOptions) {
 		branch: options.viteMajor === 4 ? 'vite-4' : 'master',
 		overrides: {
 			svelte: 'latest',
-			'@sveltejs/vite-plugin-svelte': `${pluginPath}/packages/vite-plugin-svelte`,
-			'@types/node':'^16.11.68' // override to kit's version to prevent ecosystem-ci override with vite version
+			'@sveltejs/vite-plugin-svelte': `${pluginPath}/packages/vite-plugin-svelte`
 		},
 		beforeTest: 'pnpm playwright install',
-		test: ['lint','check','test']
+		test: ['lint', 'check', 'test']
 	})
 }


### PR DESCRIPTION
Node 17 is a weird version to depend on by default. We should just get `@types/node` from the individual projects like SvelteKit. It's an optional peer dependency of Vite