### PR TITLE
fix: disable types/node override for vite-4+

### DIFF
--- a/tests/sveltekit.ts
+++ b/tests/sveltekit.ts
@@ -20,7 +20,6 @@ export async function test(options: RunOptions) {
 		overrides: {
 			svelte: 'latest',
 			'@sveltejs/vite-plugin-svelte': `${pluginPath}/packages/vite-plugin-svelte`,
-			'@types/node': '^16.11.68' // override to kit's version to prevent override with version from Vite 3. might be able to drop this with Vite 4
 		},
 		beforeTest: 'pnpm playwright install',
 		test: ['lint', 'check', 'test']

--- a/utils.ts
+++ b/utils.ts
@@ -227,10 +227,15 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 		overrides[
 			`@vitejs/plugin-legacy`
 		] ||= `${protocol}${options.vitePath}/packages/plugin-legacy`
-		const typesNodePath = fs.realpathSync(
-			`${options.vitePath}/node_modules/@types/node`
-		)
-		overrides[`@types/node`] ||= `${protocol}${typesNodePath}`
+		if(options.viteMajor < 4) {
+			// vite-3 dependency setup could have caused problems if we don't synchronize node versions
+			// vite-4 uses an optional peerDependency instead so keep project types
+			const typesNodePath = fs.realpathSync(
+				`${options.vitePath}/node_modules/@types/node`
+			)
+			overrides[`@types/node`] ||= `${protocol}${typesNodePath}`
+		}
+
 	}
 	await applyPackageOverrides(dir, pkg, overrides)
 	await beforeBuildCommand?.(pkg.scripts)


### PR DESCRIPTION
remove extra override from sveltekit test