### PR TITLE
fix: use Node.js 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - run: corepack enable
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: install

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
         id: setup-node
       - uses: denoland/setup-deno@v1
         with:

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
         id: setup-node
       - uses: denoland/setup-deno@v1
         with:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "packageManager": "pnpm@7.17.1",
   "type": "module",
   "engines": {
-    "node": "^14.14.0 || ^16 || ^18",
+    "node": ">=18",
     "pnpm": "^7.17.1"
   },
   "repository": {


### PR DESCRIPTION
Using Node.js 18 instead of Node.js 16 should fix VPS's CI.

Also potentially the Laravel CI since its TS error is also about Node.js (CC @timacdonald).

Currently failing eco CI: https://github.com/vitejs/vite/pull/11110#issuecomment-1330110858