### PR TITLE
chore: relax timeout to 30min

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -78,7 +78,7 @@ jobs:
             return comment.id
 
   execute-selected-suite:
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     needs: init
     if: "inputs.suite != '-'"
@@ -101,7 +101,7 @@ jobs:
           ${{ inputs.suite }}
 
   execute-all:
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     needs: init
     if: "inputs.suite == '-'"

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -55,7 +55,7 @@ on:
           - windicss
 jobs:
   execute-selected-suite:
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -35,7 +35,7 @@ on:
     types: [ecosystem-ci]
 jobs:
   test-ecosystem:
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
some suites (eg sveltekit) scratch the limit and it can lead to fails