### PR TITLE
fix: use token for github api call

### DIFF
--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -88,3 +88,4 @@ jobs:
           SUITE: ${{ inputs.suite }}
           STATUS: ${{ job.status }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -91,3 +91,4 @@ jobs:
           SUITE: ${{ matrix.suite }}
           STATUS: ${{ job.status }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I guess this error is happening because it reached the rate limit.
https://github.com/vitejs/vite-ecosystem-ci/actions/runs/3846033998/jobs/6550867591#step:9:16

`secrets.GITHUB_TOKEN` is now used for the GitHub API call to reduce the rate limit error happening.
I also added some logs to understand the error, in case it happens in future.
