### PR TITLE
fix: init workspace dir and add root option for eslintrc

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -69,21 +69,21 @@ export async function setupEnvironment(): Promise<EnvironmentData> {
 		YARN_ENABLE_IMMUTABLE_INSTALLS: 'false', // to avoid errors with mutated lockfile due to overrides
 		NODE_OPTIONS: '--max-old-space-size=6144', // GITHUB CI has 7GB max, stay below
 	}
-  initWorkspace(workspace);
+	initWorkspace(workspace)
 	return { root, workspace, vitePath, cwd, env }
 }
 
-function initWorkspace(workspace: string){
-	if(!fs.existsSync(workspace)) {
-		fs.mkdirSync(workspace,{recursive:true})
+function initWorkspace(workspace: string) {
+	if (!fs.existsSync(workspace)) {
+		fs.mkdirSync(workspace, { recursive: true })
 	}
-	const eslintrc = path.join(workspace,'.eslintrc.json')
-	if(!fs.existsSync(eslintrc)) {
-		fs.writeFileSync(eslintrc,'{"root":true}\n','utf-8');
+	const eslintrc = path.join(workspace, '.eslintrc.json')
+	if (!fs.existsSync(eslintrc)) {
+		fs.writeFileSync(eslintrc, '{"root":true}\n', 'utf-8')
 	}
-	const editorconfig = path.join(workspace,'.editorconfig')
-	if(!fs.existsSync(editorconfig)) {
-		fs.writeFileSync(editorconfig,'root = true\n','utf-8');
+	const editorconfig = path.join(workspace, '.editorconfig')
+	if (!fs.existsSync(editorconfig)) {
+		fs.writeFileSync(editorconfig, 'root = true\n', 'utf-8')
 	}
 }
 

--- a/utils.ts
+++ b/utils.ts
@@ -69,7 +69,22 @@ export async function setupEnvironment(): Promise<EnvironmentData> {
 		YARN_ENABLE_IMMUTABLE_INSTALLS: 'false', // to avoid errors with mutated lockfile due to overrides
 		NODE_OPTIONS: '--max-old-space-size=6144', // GITHUB CI has 7GB max, stay below
 	}
+  initWorkspace(workspace);
 	return { root, workspace, vitePath, cwd, env }
+}
+
+function initWorkspace(workspace: string){
+	if(!fs.existsSync(workspace)) {
+		fs.mkdirSync(workspace,{recursive:true})
+	}
+	const eslintrc = path.join(workspace,'.eslintrc.json')
+	if(!fs.existsSync(eslintrc)) {
+		fs.writeFileSync(eslintrc,'{"root":true}\n','utf-8');
+	}
+	const editorconfig = path.join(workspace,'.editorconfig')
+	if(!fs.existsSync(editorconfig)) {
+		fs.writeFileSync(editorconfig,'root = true\n','utf-8');
+	}
 }
 
 export async function setupRepo(options: RepoOptions) {


### PR DESCRIPTION
 and editorconfig to prevent leakage

This had caused the failure in sveltekit, that didn't specify the `"root":true` option and as a result vite-ecosystem-ci 's own rules were applied too and the test failed. To prevent our own env from leaking into the test environments in workspace, this PR adds config files to the workspace to stop traversal for eslint and editorconfig (may be used by prettier)