### PR TITLE
feat: add Nx to the tests

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -36,6 +36,7 @@ on:
           - laravel
           - marko
           - nuxt-framework
+          - nx
           - previewjs
           - qwik
           - rakkas
@@ -118,6 +119,7 @@ jobs:
           - laravel
           - marko
           - nuxt-framework
+          - nx
           - previewjs
           - qwik
           - rakkas

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -41,6 +41,7 @@ on:
           - laravel
           - marko
           - nuxt-framework
+          - nx
           - previewjs
           - qwik
           - rakkas

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -47,6 +47,7 @@ jobs:
           - laravel
           - marko
           - nuxt-framework
+          - nx
           - previewjs
           - qwik
           - rakkas

--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -6,6 +6,7 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'nrwl/nx',
 		branch: 'master',
+		build: 'build',
 		test: ['npx nx test vite', 'npx nx e2e e2e-vite'],
 	})
 }

--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -1,0 +1,11 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'nrwl/nx',
+		branch: 'master',
+		test: ['npx nx test vite', 'npx nx e2e e2e-vite'],
+	})
+}


### PR DESCRIPTION
Add Nx to the `vite-ecosystem-ci`. What this PR intends is to see if the Nx executors still work with the latest build of `vite`.