### PR TITLE
fix: use correct dir to detect package manager in use

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -209,7 +209,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 		cd(dir)
 	}
 	if (options.agent == null) {
-		const detectedAgent = await detect({ autoInstall: false })
+		const detectedAgent = await detect({ cwd: dir, autoInstall: false })
 		if (detectedAgent == null) {
 			throw new Error(`Failed to detect packagemanager in ${dir}`)
 		}


### PR DESCRIPTION
while checking out #195  i noticed that commands were run with pnpm all the time, even when the local pm was different.

It didn't cause errors from what i've seen, but we should use the tools the projects have defined