### PR TITLE
feat: add unocss

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -41,6 +41,7 @@ on:
           - rakkas
           #          - storybook  # disabled until test is updated, see https://github.com/vitejs/vite-ecosystem-ci/issues/130
           - sveltekit
+          - unocss
           - vite-plugin-ssr
           - vite-plugin-react
           - vite-plugin-react-pages
@@ -122,6 +123,7 @@ jobs:
           - rakkas
           #          - storybook  # disabled until test is updated, see https://github.com/vitejs/vite-ecosystem-ci/issues/130
           - sveltekit
+          - unocss
           - vite-plugin-ssr
           - vite-plugin-react
           - vite-plugin-react-pages

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -46,6 +46,7 @@ on:
           - rakkas
           #          - storybook  # disabled until test is updated, see https://github.com/vitejs/vite-ecosystem-ci/issues/130
           - sveltekit
+          - unocss
           - vite-plugin-ssr
           - vite-plugin-react
           - vite-plugin-react-pages

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -52,6 +52,7 @@ jobs:
           - rakkas
           #          - storybook  # disabled until test is updated, see https://github.com/vitejs/vite-ecosystem-ci/issues/130
           - sveltekit
+          - unocss
           - vite-plugin-ssr
           - vite-plugin-react
           - vite-plugin-react-pages

--- a/tests/unocss.ts
+++ b/tests/unocss.ts
@@ -1,0 +1,11 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'unocss/unocss',
+		build: 'build',
+		test: 'test',
+	})
+}


### PR DESCRIPTION
Follow up to https://github.com/vitejs/vite-ecosystem-ci/pull/209, unocss should cover the code paths that we lost after removing windi