### PR TITLE
fix: add override for new vite-plugin-svelte-inspector

### DIFF
--- a/builds/vite-plugin-svelte.ts
+++ b/builds/vite-plugin-svelte.ts
@@ -15,4 +15,5 @@ export async function build(options: RunOptions) {
 
 export const packages = {
 	'@sveltejs/vite-plugin-svelte': 'packages/vite-plugin-svelte',
+	'@sveltejs/vite-plugin-svelte-inspector': 'packages/vite-plugin-svelte-inspector',
 }

--- a/builds/vite-plugin-svelte.ts
+++ b/builds/vite-plugin-svelte.ts
@@ -15,5 +15,6 @@ export async function build(options: RunOptions) {
 
 export const packages = {
 	'@sveltejs/vite-plugin-svelte': 'packages/vite-plugin-svelte',
-	'@sveltejs/vite-plugin-svelte-inspector': 'packages/vite-plugin-svelte-inspector',
+	'@sveltejs/vite-plugin-svelte-inspector':
+		'packages/vite-plugin-svelte-inspector',
 }

--- a/tests/sveltekit.ts
+++ b/tests/sveltekit.ts
@@ -12,6 +12,7 @@ export async function test(options: RunOptions) {
 		overrides: {
 			svelte: 'latest',
 			'@sveltejs/vite-plugin-svelte': true,
+			'@sveltejs/vite-plugin-svelte-inspector': true,
 		},
 		beforeTest: 'pnpm playwright install',
 		test: ['lint', 'check', 'test:vite-ecosystem-ci'],


### PR DESCRIPTION
the package was recently split, it used to be an internal second plugin in v-p-s