### PR TITLE
feat: add analogjs test

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -29,6 +29,7 @@ on:
         type: choice
         options:
           - "-"
+          - analogjs
           - astro
           - histoire
           - iles
@@ -113,6 +114,7 @@ jobs:
     strategy:
       matrix:
         suite:
+          - analogjs
           - astro
           - histoire
           - iles

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -34,6 +34,7 @@ on:
         required: true
         type: choice
         options:
+          - analogjs
           - astro
           - histoire
           - iles

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -40,6 +40,7 @@ jobs:
     strategy:
       matrix:
         suite:
+          - analogjs
           - astro
           - histoire
           - iles

--- a/tests/analogjs.ts
+++ b/tests/analogjs.ts
@@ -1,0 +1,12 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'analogjs/analog',
+		branch: 'main',
+		build: 'build:vite-ci',
+		test: 'test:vite-ci',
+	})
+}


### PR DESCRIPTION
Hello!
This pr adds AnalogJS to the vite-ecosystem-ci.

It's still WIP as the oustanding pr ([#416](https://github.com/analogjs/analog/pull/416)) to migrate AnalogJS to `pnpm` isn't merged yet. 

But all the tests should work already.