### PR TITLE
fix: split in cli args before calling ni

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -146,6 +146,13 @@ export async function setupRepo(options: RepoOptions) {
 	}
 }
 
+function splitInCliArgs(task: string) {
+	return task
+		.split(/("[^"]+"|[^\s"]+)/gim)
+		.filter((p) => p.trim() !== '')
+		.map((p) => p.replace(/^"(.*)"$/, '$1'))
+}
+
 function toCommand(
 	task: Task | Task[] | void,
 	agent: Agent,
@@ -158,7 +165,11 @@ function toCommand(
 			} else if (typeof task === 'string') {
 				const scriptOrBin = task.trim().split(/\s+/)[0]
 				if (scripts?.[scriptOrBin] != null) {
-					const runTaskWithAgent = getCommand(agent, 'run', [task])
+					const runTaskWithAgent = getCommand(
+						agent,
+						'run',
+						splitInCliArgs(task),
+					)
 					await $`${runTaskWithAgent}`
 				} else {
 					await $`${task}`


### PR DESCRIPTION
ni started to respect the args passed to `getCommand` if they have spaces, wrapping them in quotes:
- https://github.com/antfu/ni/pull/160

I think this should do the trick for us. We could later migrate to a library to do this, for example, `--` isn't respected. We don't need support for it in vite-ecosystem-ci config at this point though. 