### PR TITLE
fix: cli args as arrays

### DIFF
--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -6,7 +6,10 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'nrwl/nx',
 		branch: 'master',
-		build: 'build-project vite --skip-nx-cache',
-		test: ['test vite --skip-nx-cache', 'e2e e2e-vite --skip-nx-cache'],
+		build: [['build-project', 'vite', '--skip-nx-cache']],
+		test: [
+			['test', 'vite', '--skip-nx-cache'],
+			['e2e', 'e2e-vite', '--skip-nx-cache'],
+		],
 	})
 }

--- a/tests/vitest.ts
+++ b/tests/vitest.ts
@@ -6,6 +6,6 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'vitest-dev/vitest',
 		build: 'build',
-		test: 'test:run --allowOnly',
+		test: [['test:run', '--allowOnly']],
 	})
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -17,14 +17,15 @@ export interface RunOptions {
 	skipGit?: boolean
 	release?: string
 	agent?: Agent
-	build?: Task | Task[]
-	test?: Task | Task[]
-	beforeInstall?: Task | Task[]
-	beforeBuild?: Task | Task[]
-	beforeTest?: Task | Task[]
+	build?: SingleArgTask | Task[]
+	test?: SingleArgTask | Task[]
+	beforeInstall?: SingleArgTask | Task[]
+	beforeBuild?: SingleArgTask | Task[]
+	beforeTest?: SingleArgTask | Task[]
 }
 
-type Task = string | (() => Promise<any>)
+type SingleArgTask = string | (() => Promise<any>)
+type Task = string | string[] | (() => Promise<any>)
 
 export interface CommandOptions {
 	suites?: string[]

--- a/utils.ts
+++ b/utils.ts
@@ -8,6 +8,7 @@ import {
 	ProcessEnv,
 	RepoOptions,
 	RunOptions,
+	SingleArgTask,
 	Task,
 } from './types'
 //eslint-disable-next-line n/no-unpublished-import
@@ -147,7 +148,7 @@ export async function setupRepo(options: RepoOptions) {
 }
 
 function toCommand(
-	task: Task | Task[] | void,
+	task: SingleArgTask | Task[] | void,
 	agent: Agent,
 ): ((scripts: any) => Promise<any>) | void {
 	return async (scripts: any) => {
@@ -155,10 +156,11 @@ function toCommand(
 		for (const task of tasks) {
 			if (task == null || task === '') {
 				continue
-			} else if (typeof task === 'string') {
-				const scriptOrBin = task.trim().split(/\s+/)[0]
+			} else if (typeof task === 'string' || Array.isArray(task)) {
+				const args = Array.isArray(task) ? task : [task]
+				const scriptOrBin = task[0].trim().split(/\s+/)[0]
 				if (scripts?.[scriptOrBin] != null) {
-					const runTaskWithAgent = getCommand(agent, 'run', [task])
+					const runTaskWithAgent = getCommand(agent, 'run', args)
 					await $`${runTaskWithAgent}`
 				} else {
 					await $`${task}`


### PR DESCRIPTION
Alternative to:
- https://github.com/vitejs/vite-ecosystem-ci/pull/233

Only support array of arrays for passing CLI args to ni.