### PR TITLE
fix: add new Task type for scripts with args so that we can pass them to ni

### DIFF
--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -6,7 +6,10 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'nrwl/nx',
 		branch: 'master',
-		build: 'build-project vite --skip-nx-cache',
-		test: ['test vite --skip-nx-cache', 'e2e e2e-vite --skip-nx-cache'],
+		build: { script: 'build-project', args: ['vite', '--skip-nx-cache'] },
+		test: [
+			{ script: 'test', args: ['vite', '--skip-nx-cache'] },
+			{ script: 'e2e', args: ['e2e-vite', '--skip-nx-cache'] },
+		],
 	})
 }

--- a/tests/vitest.ts
+++ b/tests/vitest.ts
@@ -6,6 +6,6 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'vitest-dev/vitest',
 		build: 'build',
-		test: 'test:run --allowOnly',
+		test: { script: 'test:run', args: ['--allowOnly'] },
 	})
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -24,7 +24,7 @@ export interface RunOptions {
 	beforeTest?: Task | Task[]
 }
 
-type Task = string | (() => Promise<any>)
+type Task = string | { script: string; args?: string[] } | (() => Promise<any>)
 
 export interface CommandOptions {
 	suites?: string[]

--- a/utils.ts
+++ b/utils.ts
@@ -156,8 +156,7 @@ function toCommand(
 			if (task == null || task === '') {
 				continue
 			} else if (typeof task === 'string') {
-				const scriptOrBin = task.trim().split(/\s+/)[0]
-				if (scripts?.[scriptOrBin] != null) {
+				if (scripts[task] != null) {
 					const runTaskWithAgent = getCommand(agent, 'run', [task])
 					await $`${runTaskWithAgent}`
 				} else {
@@ -165,6 +164,18 @@ function toCommand(
 				}
 			} else if (typeof task === 'function') {
 				await task()
+			} else if (task?.script) {
+				if (scripts[task.script] != null) {
+					const runTaskWithAgent = getCommand(agent, 'run', [
+						task.script,
+						...(task.args ?? []),
+					])
+					await $`${runTaskWithAgent}`
+				} else {
+					throw new Error(
+						`invalid task, script "${task.script}" does not exist in package.json`,
+					)
+				}
 			} else {
 				throw new Error(
 					`invalid task, expected string or function but got ${typeof task}: ${task}`,


### PR DESCRIPTION
third option to #233 and #234

being more explicit with an object allows us to get rid of the split that was previously used for scripts with args