### PR TITLE
chore: run playwright install to avoid nuxt test error

### DIFF
--- a/tests/nuxt.ts
+++ b/tests/nuxt.ts
@@ -12,7 +12,7 @@ export async function test(options: RunOptions) {
 			'@vitejs/plugin-vue': true,
 		},
 		build: 'build',
-		beforeTest: 'pnpm playwright install',
+		beforeTest: 'pnpm playwright-core install',
 		test: ['test:fixtures', 'test:types'],
 	})
 }

--- a/tests/nuxt.ts
+++ b/tests/nuxt.ts
@@ -12,6 +12,7 @@ export async function test(options: RunOptions) {
 			'@vitejs/plugin-vue': true,
 		},
 		build: 'build',
+		beforeTest: 'pnpm playwright install',
 		test: ['test:fixtures', 'test:types'],
 	})
 }


### PR DESCRIPTION
see https://github.com/vitejs/vite-ecosystem-ci/actions/runs/6218411148/job/16874862943#step:8:1049

it complains about installed playwright bin so  install that (see also sveltekit / vite-plugin-svelte doing the same)