### PR TITLE
vite-plugin-ssr renamed to Vike

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -129,8 +129,8 @@ jobs:
           #          - storybook  # disabled until test is updated, see https://github.com/vitejs/vite-ecosystem-ci/issues/130
           - sveltekit
           - unocss
-          - vite-plugin-pwa
           - vike
+          - vite-plugin-pwa
           - vite-plugin-react
           - vite-plugin-react-pages
           - vite-plugin-react-swc

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -44,8 +44,8 @@ on:
           #          - storybook  # disabled until test is updated, see https://github.com/vitejs/vite-ecosystem-ci/issues/130
           - sveltekit
           - unocss
-          - vite-plugin-pwa
           - vike
+          - vite-plugin-pwa
           - vite-plugin-react
           - vite-plugin-react-pages
           - vite-plugin-react-swc

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -45,7 +45,7 @@ on:
           - sveltekit
           - unocss
           - vite-plugin-pwa
-          - vite-plugin-ssr
+          - vike
           - vite-plugin-react
           - vite-plugin-react-pages
           - vite-plugin-react-swc
@@ -130,7 +130,7 @@ jobs:
           - sveltekit
           - unocss
           - vite-plugin-pwa
-          - vite-plugin-ssr
+          - vike
           - vite-plugin-react
           - vite-plugin-react-pages
           - vite-plugin-react-swc

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -49,8 +49,8 @@ on:
           #          - storybook  # disabled until test is updated, see https://github.com/vitejs/vite-ecosystem-ci/issues/130
           - sveltekit
           - unocss
-          - vite-plugin-pwa
           - vike
+          - vite-plugin-pwa
           - vite-plugin-react
           - vite-plugin-react-pages
           - vite-plugin-react-swc

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -50,7 +50,7 @@ on:
           - sveltekit
           - unocss
           - vite-plugin-pwa
-          - vite-plugin-ssr
+          - vike
           - vite-plugin-react
           - vite-plugin-react-pages
           - vite-plugin-react-swc

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -55,8 +55,8 @@ jobs:
           #          - storybook  # disabled until test is updated, see https://github.com/vitejs/vite-ecosystem-ci/issues/130
           - sveltekit
           - unocss
-          - vite-plugin-pwa
           - vike
+          - vite-plugin-pwa
           - vite-plugin-react
           - vite-plugin-react-pages
           - vite-plugin-react-swc

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -56,7 +56,7 @@ jobs:
           - sveltekit
           - unocss
           - vite-plugin-pwa
-          - vite-plugin-ssr
+          - vike
           - vite-plugin-react
           - vite-plugin-react-pages
           - vite-plugin-react-swc

--- a/tests/vike.ts
+++ b/tests/vike.ts
@@ -4,7 +4,7 @@ import { RunOptions } from '../types'
 export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
-		repo: 'brillout/vite-plugin-ssr',
+		repo: 'vikejs/vike',
 		branch: 'main',
 		overrides: {
 			'@vitejs/plugin-react': true,


### PR DESCRIPTION
The vite-plugin-ssr project has been renamed to Vike.
 - [vike.dev](https://vike.dev)
 - [github.com/vikejs/vike](https://github.com/vikejs/vike)