### PR TITLE
fix: use non-truncated ref for links in discord

### DIFF
--- a/discord-webhook.ts
+++ b/discord-webhook.ts
@@ -169,8 +169,9 @@ function createTargetText(
 ) {
 	const repoText = repo !== 'vitejs/vite' ? `${repo}:` : ''
 	if (refType === 'branch') {
+		const shortRef = permRef?.slice(0, 7)
 		const link = `https://github.com/${repo}/commits/${permRef || ref}`
-		return `[${repoText}${ref} (${permRef || 'unknown'})](${link})`
+		return `[${repoText}${ref} (${shortRef || 'unknown'})](${link})`
 	}
 
 	const refTypeText = refType === 'release' ? ' (release)' : ''

--- a/utils.ts
+++ b/utils.ts
@@ -350,7 +350,7 @@ export async function setupViteRepo(options: Partial<RepoOptions>) {
 export async function getPermanentRef() {
 	cd(vitePath)
 	try {
-		const ref = await $`git log -1 --pretty=format:%h`
+		const ref = await $`git log -1 --pretty=format:%H`
 		return ref
 	} catch (e) {
 		console.warn(`Failed to obtain perm ref. ${e}`)


### PR DESCRIPTION
`git log -1 --pretty=format:%h` returns an ambiguous ref.
https://discord.com/channels/804011606160703521/1162083505812025384/1162318471745515541
