### PR TITLE
chore: remove special handling for vite-3

### DIFF
--- a/tests/histoire.ts
+++ b/tests/histoire.ts
@@ -2,9 +2,6 @@ import { runInRepo } from '../utils'
 import { RunOptions } from '../types'
 
 export async function test(options: RunOptions) {
-	if (options.viteMajor < 4) {
-		return // no branch for vite 3
-	}
 	await runInRepo({
 		...options,
 		repo: 'histoire-dev/histoire',

--- a/tests/ladle.ts
+++ b/tests/ladle.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'tajo/ladle',
-		branch: options.viteMajor === 4 ? 'vite-4' : 'main',
+		branch: 'main',
 		build: 'build',
 		beforeTest: 'pnpm playwright install chromium',
 		test: 'test',

--- a/tests/nuxt.ts
+++ b/tests/nuxt.ts
@@ -2,9 +2,6 @@ import { runInRepo } from '../utils'
 import { RunOptions } from '../types'
 
 export async function test(options: RunOptions) {
-	if (options.viteMajor < 4) {
-		return // no branch for vite 3
-	}
 	await runInRepo({
 		...options,
 		repo: 'nuxt/nuxt',

--- a/tests/sveltekit.ts
+++ b/tests/sveltekit.ts
@@ -2,9 +2,6 @@ import { runInRepo } from '../utils'
 import { RunOptions } from '../types'
 
 export async function test(options: RunOptions) {
-	if (options.viteMajor < 4) {
-		return // no branch with 3.0 version
-	}
 	await runInRepo({
 		...options,
 		repo: 'sveltejs/kit',

--- a/tests/vite-plugin-pwa.ts
+++ b/tests/vite-plugin-pwa.ts
@@ -2,11 +2,6 @@ import { runInRepo } from '../utils'
 import { RunOptions } from '../types'
 
 export async function test(options: RunOptions) {
-	if (options.viteMajor < 4) {
-		// only latest version
-		return
-	}
-
 	await runInRepo({
 		...options,
 		repo: 'vite-pwa/vite-plugin-pwa',

--- a/tests/vite-plugin-react-swc.ts
+++ b/tests/vite-plugin-react-swc.ts
@@ -2,7 +2,6 @@ import { runInRepo } from '../utils'
 import { RunOptions } from '../types'
 
 export async function test(options: RunOptions) {
-	if (options.viteMajor < 4) return
 	await runInRepo({
 		...options,
 		repo: 'vitejs/vite-plugin-react-swc',

--- a/tests/vite-plugin-svelte.ts
+++ b/tests/vite-plugin-svelte.ts
@@ -2,9 +2,6 @@ import { runInRepo } from '../utils'
 import { RunOptions } from '../types'
 
 export async function test(options: RunOptions) {
-	if (options.viteMajor < 4) {
-		return
-	}
 	await runInRepo({
 		...options,
 		repo: 'sveltejs/vite-plugin-svelte',

--- a/tests/vitepress.ts
+++ b/tests/vitepress.ts
@@ -2,9 +2,6 @@ import { runInRepo } from '../utils'
 import { RunOptions } from '../types'
 
 export async function test(options: RunOptions) {
-	if (options.viteMajor < 4) {
-		return // no branch for vite 3
-	}
 	await runInRepo({
 		...options,
 		repo: 'vuejs/vitepress',

--- a/utils.ts
+++ b/utils.ts
@@ -270,30 +270,13 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 		overrides[
 			`@vitejs/plugin-legacy`
 		] ||= `${options.vitePath}/packages/plugin-legacy`
-		if (options.viteMajor < 4) {
-			overrides[
-				`@vitejs/plugin-vue`
-			] ||= `${options.vitePath}/packages/plugin-vue`
-			overrides[
-				`@vitejs/plugin-vue-jsx`
-			] ||= `${options.vitePath}/packages/plugin-vue-jsx`
-			overrides[
-				`@vitejs/plugin-react`
-			] ||= `${options.vitePath}/packages/plugin-react`
-			// vite-3 dependency setup could have caused problems if we don't synchronize node versions
-			// vite-4 uses an optional peerDependency instead so keep project types
-			const typesNodePath = fs.realpathSync(
-				`${options.vitePath}/node_modules/@types/node`,
-			)
-			overrides[`@types/node`] ||= `${typesNodePath}`
-		} else {
-			// starting with vite-4, we apply automatic overrides
-			const localOverrides = await buildOverrides(pkg, options, overrides)
-			cd(dir) // buildOverrides changed dir, change it back
-			overrides = {
-				...overrides,
-				...localOverrides,
-			}
+
+		// build and apply local overrides
+		const localOverrides = await buildOverrides(pkg, options, overrides)
+		cd(dir) // buildOverrides changed dir, change it back
+		overrides = {
+			...overrides,
+			...localOverrides,
 		}
 	}
 	await applyPackageOverrides(dir, pkg, overrides)


### PR DESCRIPTION
we are not going to run ecosystem-ci on vite-3 anymore so this is no longer needed. Hopefully we won't have to reintroduce similar checks for vite4/5 :crossed_fingers: 