### PR TITLE
fix(marko): install playwright chromium before testing

### DIFF
--- a/tests/marko.ts
+++ b/tests/marko.ts
@@ -7,6 +7,7 @@ export async function test(options: RunOptions) {
 		repo: 'marko-js/vite',
 		dir: 'marko', // default is last segment of repo, which would be vite and confusing
 		build: 'build',
+		beforeTest: 'pnpm playwright install chromium',
 		test: 'test',
 		overrides: {
 			esbuild: `${options.vitePath}/packages/vite/node_modules/esbuild`,


### PR DESCRIPTION
Not sure why it's failing recently, but maybe we should install chromium before testing like the other frameworks.

Failed run: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/6583609019/job/17886920362#step:8:744