### PR TITLE
fix(nx): skip rollup overrides

### DIFF
--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -11,5 +11,8 @@ export async function test(options: RunOptions) {
 			{ script: 'test', args: ['vite', '--skip-nx-cache'] },
 			{ script: 'e2e', args: ['e2e-vite', '--skip-nx-cache'] },
 		],
+		overrides: {
+			rollup: false,
+		},
 	})
 }

--- a/utils.ts
+++ b/utils.ts
@@ -272,11 +272,11 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 			`@vitejs/plugin-legacy`
 		] ||= `${options.vitePath}/packages/plugin-legacy`
 
-		if (overrides.rollup !== false) {
-			const vitePackageInfo = await getVitePackageInfo(options.vitePath)
-			if (vitePackageInfo.dependencies.rollup?.version && !overrides.rollup) {
-				overrides.rollup = vitePackageInfo.dependencies.rollup.version
-			}
+		const vitePackageInfo = await getVitePackageInfo(options.vitePath)
+		//skip if `overrides.rollup` is `false`
+		if (vitePackageInfo.dependencies.rollup?.version && overrides.rollup == null) {
+			overrides.rollup = vitePackageInfo.dependencies.rollup.version
+		}
 		}
 
 		// build and apply local overrides

--- a/utils.ts
+++ b/utils.ts
@@ -272,9 +272,11 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 			`@vitejs/plugin-legacy`
 		] ||= `${options.vitePath}/packages/plugin-legacy`
 
-		const vitePackageInfo = await getVitePackageInfo(options.vitePath)
-		if (vitePackageInfo.dependencies.rollup?.version && !overrides.rollup) {
-			overrides.rollup = vitePackageInfo.dependencies.rollup.version
+		if (overrides.rollup !== false) {
+			const vitePackageInfo = await getVitePackageInfo(options.vitePath)
+			if (vitePackageInfo.dependencies.rollup?.version && !overrides.rollup) {
+				overrides.rollup = vitePackageInfo.dependencies.rollup.version
+			}
 		}
 
 		// build and apply local overrides

--- a/utils.ts
+++ b/utils.ts
@@ -277,7 +277,6 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 		if (vitePackageInfo.dependencies.rollup?.version && overrides.rollup == null) {
 			overrides.rollup = vitePackageInfo.dependencies.rollup.version
 		}
-		}
 
 		// build and apply local overrides
 		const localOverrides = await buildOverrides(pkg, options, overrides)

--- a/utils.ts
+++ b/utils.ts
@@ -273,7 +273,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 		] ||= `${options.vitePath}/packages/plugin-legacy`
 
 		const vitePackageInfo = await getVitePackageInfo(options.vitePath)
-		//skip if `overrides.rollup` is `false`
+		// skip if `overrides.rollup` is `false`
 		if (
 			vitePackageInfo.dependencies.rollup?.version &&
 			overrides.rollup == null

--- a/utils.ts
+++ b/utils.ts
@@ -276,7 +276,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 		// skip if `overrides.rollup` is `false`
 		if (
 			vitePackageInfo.dependencies.rollup?.version &&
-			overrides.rollup == null
+			overrides.rollup !== false
 		) {
 			overrides.rollup = vitePackageInfo.dependencies.rollup.version
 		}

--- a/utils.ts
+++ b/utils.ts
@@ -274,7 +274,10 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 
 		const vitePackageInfo = await getVitePackageInfo(options.vitePath)
 		//skip if `overrides.rollup` is `false`
-		if (vitePackageInfo.dependencies.rollup?.version && overrides.rollup == null) {
+		if (
+			vitePackageInfo.dependencies.rollup?.version &&
+			overrides.rollup == null
+		) {
 			overrides.rollup = vitePackageInfo.dependencies.rollup.version
 		}
 


### PR DESCRIPTION
This makes nx pass: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/6728289738/job/18287407127