### PR TITLE
fix: fix typecheck and run it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
         run: pnpm format
       - name: lint
         run: pnpm run lint
+      - name: typecheck
+        run: pnpm run typecheck
       - name: audit
         if: (${{ success() }} || ${{ failure() }})
         run: pnpm audit

--- a/builds/vite-plugin-react.ts
+++ b/builds/vite-plugin-react.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function build(options: RunOptions) {
 	return runInRepo({

--- a/builds/vite-plugin-svelte.ts
+++ b/builds/vite-plugin-svelte.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function build(options: RunOptions) {
 	if (options.viteMajor < 4) {

--- a/builds/vite-plugin-vue.ts
+++ b/builds/vite-plugin-vue.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function build(options: RunOptions) {
 	return runInRepo({

--- a/discord-webhook.ts
+++ b/discord-webhook.ts
@@ -1,5 +1,5 @@
 import fetch from 'node-fetch'
-import { getPermanentRef, setupEnvironment } from './utils'
+import { getPermanentRef, setupEnvironment } from './utils.ts'
 
 type RefType = 'branch' | 'tag' | 'commit' | 'release'
 type Status = 'success' | 'failure' | 'cancelled'

--- a/ecosystem-ci.ts
+++ b/ecosystem-ci.ts
@@ -10,8 +10,8 @@ import {
 	bisectVite,
 	parseViteMajor,
 	parseMajorVersion,
-} from './utils'
-import { CommandOptions, RunOptions } from './types'
+} from './utils.ts'
+import type { CommandOptions, RunOptions } from './types.d.ts'
 
 const cli = cac()
 cli

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "prepare": "pnpm exec simple-git-hooks",
     "lint": "eslint --ignore-path .gitignore '**/*.ts'",
     "lint:fix": "pnpm lint --fix",
+    "typecheck": "tsc",
     "format": "prettier --ignore-path .gitignore --check .",
     "format:fix": "pnpm format --write",
     "test:self": "tsx ecosystem-ci.ts _selftest",

--- a/tests/_hydrogen.ts
+++ b/tests/_hydrogen.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/_iles.ts
+++ b/tests/_iles.ts
@@ -1,5 +1,5 @@
-import { runInRepo, $ } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo, $ } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/_selftest.ts
+++ b/tests/_selftest.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import fs from 'fs'
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/_storybook.ts
+++ b/tests/_storybook.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/analogjs.ts
+++ b/tests/analogjs.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/astro.ts
+++ b/tests/astro.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/histoire.ts
+++ b/tests/histoire.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/ladle.ts
+++ b/tests/ladle.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/laravel.ts
+++ b/tests/laravel.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	//see https://github.com/laravel/vite-plugin/blob/73466441b0c9eb0c1a5ce0a0e937bd83eaef4b70/.github/workflows/tests.yml#L10

--- a/tests/marko.ts
+++ b/tests/marko.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/nuxt.ts
+++ b/tests/nuxt.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/previewjs.ts
+++ b/tests/previewjs.ts
@@ -1,5 +1,5 @@
-import { RunOptions } from '../types'
-import { runInRepo } from '../utils'
+import type { RunOptions } from '../types.d.ts'
+import { runInRepo } from '../utils.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/qwik.ts
+++ b/tests/qwik.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/rakkas.ts
+++ b/tests/rakkas.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/sveltekit.ts
+++ b/tests/sveltekit.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/unocss.ts
+++ b/tests/unocss.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/vike.ts
+++ b/tests/vike.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/vite-plugin-laravel.ts
+++ b/tests/vite-plugin-laravel.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/vite-plugin-pwa.ts
+++ b/tests/vite-plugin-pwa.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/vite-plugin-react-pages.ts
+++ b/tests/vite-plugin-react-pages.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/vite-plugin-react-swc.ts
+++ b/tests/vite-plugin-react-swc.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/vite-plugin-react.ts
+++ b/tests/vite-plugin-react.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/vite-plugin-svelte.ts
+++ b/tests/vite-plugin-svelte.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/vite-plugin-vue.ts
+++ b/tests/vite-plugin-vue.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/vite-setup-catalogue.ts
+++ b/tests/vite-setup-catalogue.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/vitepress.ts
+++ b/tests/vitepress.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tests/vitest.ts
+++ b/tests/vitest.ts
@@ -1,5 +1,5 @@
-import { runInRepo } from '../utils'
-import { RunOptions } from '../types'
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
 	await runInRepo({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,13 @@
 {
 	"include": ["./**/*.ts"],
-	"exclude": ["**/node_modules/**"],
+	"exclude": ["**/node_modules/**", "./workspace/**"],
 	"compilerOptions": {
 		"target": "esnext",
 		"module": "nodenext",
-		"moduleResolution": "node",
+		"moduleResolution": "nodenext",
+		"allowImportingTsExtensions": true,
+		"noEmit": true,
+		"skipLibCheck": true,
 		"strict": true,
 		"declaration": true,
 		"noImplicitOverride": true,

--- a/utils.ts
+++ b/utils.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import fs from 'fs'
 import { fileURLToPath, pathToFileURL } from 'url'
 import { execaCommand } from 'execa'
-import {
+import type {
 	PackageInfo,
 	EnvironmentData,
 	Overrides,
@@ -10,7 +10,7 @@ import {
 	RepoOptions,
 	RunOptions,
 	Task,
-} from './types'
+} from './types.d.ts'
 //eslint-disable-next-line n/no-unpublished-import
 import { detect, AGENTS, Agent, getCommand } from '@antfu/ni'
 import actionsCore from '@actions/core'
@@ -58,7 +58,6 @@ export async function $(literals: TemplateStringsArray, ...values: any[]) {
 }
 
 export async function setupEnvironment(): Promise<EnvironmentData> {
-	// @ts-expect-error import.meta
 	const root = dirnameFrom(import.meta.url)
 	const workspace = path.resolve(root, 'workspace')
 	vitePath = path.resolve(workspace, 'vite')


### PR DESCRIPTION
Running `pnpm tsc --noEmit` showed many errors. This PR fixes that and also add `pnpm typecheck` and runs that in CI.