### PR TITLE
fix: place empty tsconfig for fallback

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -87,6 +87,10 @@ function initWorkspace(workspace: string) {
 	if (!fs.existsSync(editorconfig)) {
 		fs.writeFileSync(editorconfig, 'root = true\n', 'utf-8')
 	}
+	const tsconfig = path.join(workspace, 'tsconfig.json')
+	if (!fs.existsSync(tsconfig)) {
+		fs.writeFileSync(tsconfig, '{}\n', 'utf-8')
+	}
 }
 
 export async function setupRepo(options: RepoOptions) {


### PR DESCRIPTION
This PR fixes the fail for histoire. It was caused by https://github.com/cypress-io/cypress/issues/28442.
Placing an empty tsconfig in the workspace root would fix this.

https://github.com/sapphi-red/vite-ecosystem-ci/actions/runs/7059741810/job/19217929986
