### PR TITLE
chore(tests): switch sveltekit to version-2 branch

### DIFF
--- a/tests/sveltekit.ts
+++ b/tests/sveltekit.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'sveltejs/kit',
-		branch: 'master',
+		branch: 'version-2',
 		overrides: {
 			svelte: 'latest',
 			'@sveltejs/vite-plugin-svelte': true,


### PR DESCRIPTION
vite 5 support in sveltekit is going to be in version-2.