### PR TITLE
chore: update sveltekit default branch

### DIFF
--- a/tests/sveltekit.ts
+++ b/tests/sveltekit.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'sveltejs/kit',
-		branch: 'version-2',
+		branch: 'main',
 		overrides: {
 			svelte: 'latest',
 			'@sveltejs/vite-plugin-svelte': true,


### PR DESCRIPTION
version-2 has been merged. 

Draft state bc current default is still master, waiting for the rename to happen