### PR TITLE
docs: remove note about pnpm-focused utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ See [docs/pr-comment-setup.md](./docs/pr-comment-setup.md) for how to setup this
 - check out the existing [tests](./tests) and add one yourself. Thanks to some utilities it is really easy
 - once you are confidente the suite works, add it to the lists of suites in the [workflows](../../actions/)
 
-> the current utilities focus on pnpm based projects. Consider switching to pnpm or contribute utilities for other pms
-
 # reporting results
 
 ## Discord


### PR DESCRIPTION
Since Remix is currently using Yarn (albeit with plans to move to pnpm) I initially thought Remix would first need to migrate to pnpm before adding a test to this repo based on this line in the readme, but was later told that this is outdated.