### PR TITLE
fix: ensure pnpm binary is only called in vite dir to get vite package info

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -611,8 +611,12 @@ async function buildOverrides(
  */
 async function getVitePackageInfo(vitePath: string): Promise<PackageInfo> {
 	try {
-		const lsOutput = await $`pnpm --dir ${vitePath}/packages/vite ls --json`
-		const lsParsed = JSON.parse(lsOutput)
+		// run in vite dir to avoid package manager mismatch error from corepack
+		const current = cwd
+		cd(`${vitePath}/packages/vite`)
+		const lsOutput = $`pnpm ls --json`
+		cd(current)
+		const lsParsed = JSON.parse(await lsOutput)
 		return lsParsed[0] as PackageInfo
 	} catch (e) {
 		console.error('failed to retrieve vite package infos', e)


### PR DESCRIPTION
so that it works even when the test project is not using pnpm

see https://discord.com/channels/804011606160703521/1196724390998577203/1196758463158693899