### PR TITLE
fix: also run nuxt dev fixtures

### DIFF
--- a/tests/nuxt.ts
+++ b/tests/nuxt.ts
@@ -1,7 +1,7 @@
 import { runInRepo } from '../utils.ts'
 import type { RunOptions } from '../types.d.ts'
 
-export async function test (options: RunOptions) {
+export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'nuxt/nuxt',

--- a/tests/nuxt.ts
+++ b/tests/nuxt.ts
@@ -1,7 +1,7 @@
 import { runInRepo } from '../utils.ts'
 import type { RunOptions } from '../types.d.ts'
 
-export async function test(options: RunOptions) {
+export async function test (options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'nuxt/nuxt',
@@ -10,6 +10,6 @@ export async function test(options: RunOptions) {
 		},
 		build: 'build',
 		beforeTest: 'pnpm playwright-core install',
-		test: ['test:fixtures', 'test:types'],
+		test: ['test:fixtures', 'test:fixtures:dev', 'test:types'],
 	})
 }


### PR DESCRIPTION
Updating to vite v5.2.0 seems to have a regression for Nuxt, but only in development. (See https://github.com/nuxt/nuxt/pull/26399.)

This enables running dev tests in vite ecosystem CI in future.