### PR TITLE
fix: temporary use Vike's `brillout/pnpm-8` branch

### DIFF
--- a/tests/vike.ts
+++ b/tests/vike.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'vikejs/vike',
-		branch: 'main',
+		branch: 'brillout/pnpm-8',
 		overrides: {
 			'@vitejs/plugin-react': true,
 			'@vitejs/plugin-vue': true,


### PR DESCRIPTION
Vike's `main` branch uses pnpm 9 while `vite-ecosystem-ci` uses pnpm 8. This causes `vite-ecosystem-ci` + Vike to fail.

This PR is a temporary workaround. I'll revert this PR once Vite uses pnpm 9.