### PR TITLE
feat: add Storybook back to vite-ecosystem-ci

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -145,7 +145,7 @@ jobs:
           - qwik
           - rakkas
           - remix
-          # - storybook # disabled until test is updated, see https://github.com/vitejs/vite-ecosystem-ci/issues/130
+          - storybook
           - sveltekit
           - unocss
           - vike

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -59,7 +59,7 @@ jobs:
           - qwik
           - rakkas
           - remix
-          # - storybook # disabled until test is updated, see https://github.com/vitejs/vite-ecosystem-ci/issues/130
+          - storybook
           - sveltekit
           - unocss
           - vike

--- a/tests/storybook.ts
+++ b/tests/storybook.ts
@@ -4,9 +4,10 @@ import type { RunOptions } from '../types.d.ts'
 export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
-		repo: 'storybookjs/builder-vite',
-		branch: 'main',
-		build: 'prepublish',
-		test: ['build-examples', 'test-ci'],
+		repo: 'storybookjs/storybook',
+		branch: 'next',
+		build: 'vite-ecosystem-ci:build',
+		beforeTest: 'vite-ecosystem-ci:before-test',
+		test: 'vite-ecosystem-ci:test',
 	})
 }


### PR DESCRIPTION
Supersedes https://github.com/vitejs/vite-ecosystem-ci/pull/307 and https://github.com/vitejs/vite-ecosystem-ci/pull/137.

Second attempt: I have provided some scripts for the ecosystem-ci in Storybook's monorepo. I had to introduce a `before-test` script on our side to copy over the resolutions field from the root's `package.json` to the package.json of the created sandbox: https://github.com/storybookjs/storybook/pull/27518/files, but this should be fine I guess.