### PR TITLE
feat: add vite-environment-examples

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -61,6 +61,7 @@ on:
           - vitepress
           - vitest
           - vuepress
+          - vite-environment-examples
 jobs:
   init:
     runs-on: ubuntu-latest

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -51,6 +51,7 @@ on:
           - sveltekit
           - unocss
           - vike
+          - vite-environment-examples
           - vite-plugin-pwa
           - vite-plugin-react
           - vite-plugin-react-pages
@@ -61,7 +62,6 @@ on:
           - vitepress
           - vitest
           - vuepress
-          - vite-environment-examples
 jobs:
   init:
     runs-on: ubuntu-latest

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -67,6 +67,7 @@ on:
           - vitepress
           - vitest
           - vuepress
+          - vite-environment-examples
 jobs:
   execute-selected-suite:
     timeout-minutes: 30

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -57,6 +57,7 @@ on:
           - sveltekit
           - unocss
           - vike
+          - vite-environment-examples
           - vite-plugin-pwa
           - vite-plugin-react
           - vite-plugin-react-pages
@@ -67,7 +68,6 @@ on:
           - vitepress
           - vitest
           - vuepress
-          - vite-environment-examples
 jobs:
   execute-selected-suite:
     timeout-minutes: 30

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -63,6 +63,7 @@ jobs:
           - sveltekit
           - unocss
           - vike
+          - vite-environment-examples
           - vite-plugin-pwa
           - vite-plugin-react
           - vite-plugin-react-pages
@@ -73,7 +74,6 @@ jobs:
           - vitepress
           - vitest
           - vuepress
-          - vite-environment-examples
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -73,6 +73,7 @@ jobs:
           - vitepress
           - vitest
           - vuepress
+          - vite-environment-examples
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/tests/vite-environment-examples.ts
+++ b/tests/vite-environment-examples.ts
@@ -1,0 +1,16 @@
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
+
+export async function test(options: RunOptions) {
+	if (options.viteMajor < 6) {
+		return
+	}
+	await runInRepo({
+		...options,
+		repo: 'hi-ogawa/vite-environment-examples',
+		branch: 'main',
+		build: 'vite-ecosystem-ci:build',
+		beforeTest: 'vite-ecosystem-ci:before-test',
+		test: 'vite-ecosystem-ci:test',
+	})
+}


### PR DESCRIPTION
As discussed with @patak-dev, this PR adds https://github.com/hi-ogawa/vite-environment-examples to ecosystem ci.

I verified the test passes locally by:

```sh
pnpm tsx ecosystem-ci.ts --branch v6/environment-api vite-environment-examples
```