### PR TITLE
chore: disable vite-plugin-react-pages

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -153,7 +153,7 @@ jobs:
           - vike
           - vite-plugin-pwa
           - vite-plugin-react
-          - vite-plugin-react-pages
+          # - vite-plugin-react-pages # # disabled until its install setup is fixed
           - vite-plugin-react-swc
           - vite-plugin-svelte
           - vite-plugin-vue

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -66,7 +66,7 @@ jobs:
           - vite-environment-examples
           - vite-plugin-pwa
           - vite-plugin-react
-          - vite-plugin-react-pages
+          # - vite-plugin-react-pages # disabled until its install setup is fixed
           - vite-plugin-react-swc
           - vite-plugin-svelte
           - vite-plugin-vue


### PR DESCRIPTION
I believe @patak-dev has contacted @csr632 (who maintains `vite-plugin-react-pages`) before but it's not clear whether the CI will be fixed. It has been failing since June and it would be good to prevent resources spent on a known fail.