### PR TITLE
fix: allow colors in CI

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -80,7 +80,6 @@ export async function setupEnvironment(): Promise<EnvironmentData> {
 		YARN_ENABLE_IMMUTABLE_INSTALLS: 'false', // to avoid errors with mutated lockfile due to overrides
 		NODE_OPTIONS: '--max-old-space-size=6144', // GITHUB CI has 7GB max, stay below
 		ECOSYSTEM_CI: 'true', // flag for tests, can be used to conditionally skip irrelevant tests.
-		NO_COLOR: '1',
 	}
 	initWorkspace(workspace)
 	return { root, workspace, vitePath, cwd, env }


### PR DESCRIPTION
Allow colors in CI so it's easier to read the logs, and possibly fix the Vike fail