### PR TITLE
fix: add vite-environment-examples to execute-all

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -151,6 +151,7 @@ jobs:
           - sveltekit
           - unocss
           - vike
+          - vite-environment-examples
           - vite-plugin-pwa
           - vite-plugin-react
           # - vite-plugin-react-pages # # disabled until its install setup is fixed


### PR DESCRIPTION
I was wondering why it's not appearing in the list https://github.com/vitejs/vite/pull/16471/#issuecomment-2315399812 and I think I just forgot to add it to one more place :sweat_smile: