### PR TITLE
feat: add redwoodjs and vuepress to from-pr list

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -147,6 +147,7 @@ jobs:
           - quasar
           - qwik
           - rakkas
+          - redwoodjs
           - remix
           - storybook
           - sveltekit
@@ -162,6 +163,7 @@ jobs:
           - vite-setup-catalogue
           - vitepress
           - vitest
+          - vuepress
       fail-fast: false
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
We are missing two projects in the from-pr list (that we test in the regular run)