### PR TITLE
fix(vuepress): install playwright chromium before testing

### DIFF
--- a/tests/vuepress.ts
+++ b/tests/vuepress.ts
@@ -10,6 +10,7 @@ export async function test(options: RunOptions) {
 		},
 		branch: 'main',
 		build: 'build',
+		beforeTest: 'pnpm --filter e2e exec playwright install chromium',
 		test: 'test',
 	})
 }


### PR DESCRIPTION
Probably needs to add this for vuepress as well.

Failed run: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/11098468509/job/30834087016#step:8:1727


