### PR TITLE
fix: use svelte 4 for sveltekit for now

### DIFF
--- a/tests/sveltekit.ts
+++ b/tests/sveltekit.ts
@@ -7,9 +7,9 @@ export async function test(options: RunOptions) {
 		repo: 'sveltejs/kit',
 		branch: 'main',
 		overrides: {
-			svelte: 'latest',
-			'@sveltejs/vite-plugin-svelte': true,
-			'@sveltejs/vite-plugin-svelte-inspector': true,
+			// svelte: 'latest',
+			// '@sveltejs/vite-plugin-svelte': true,
+			// '@sveltejs/vite-plugin-svelte-inspector': true,
 		},
 		beforeTest: 'pnpm playwright install',
 		test: ['lint', 'check', 'test:vite-ecosystem-ci'],


### PR DESCRIPTION
Using svelte 5 with svelte kit is causing type errors.
https://discord.com/channels/804011606160703521/928398470086291456/1299236704510672897
