### PR TITLE
chore: run with updated Vitest for Vite 6

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -297,6 +297,10 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 			...localOverrides,
 		}
 	}
+	// override Vitest so that it's compatible with Vite 6
+	if (options.viteMajor >= 6 && options.repo !== 'vitest-dev/vitest') {
+		overrides.vitest = '2.2.0-beta.1'
+	}
 	await applyPackageOverrides(dir, pkg, overrides)
 	await beforeBuildCommand?.(pkg.scripts)
 	await buildCommand?.(pkg.scripts)


### PR DESCRIPTION
To try out if https://github.com/vitest-dev/vitest/commit/251893b41caaff26b9c3fb59cb79216bec9d149f fixes some tests.

Without this PR the following tests fail:

- histoire
- **vite-plugin-react**
- astro
- waku
- vitest
- sveltekit
- redwoodjs
- vite-plugin-svelte
- vike
- remix

With this PR the following tests fail:

- histoire
- astro
- waku
- vitest
- sveltekit
- redwoodjs
- vite-plugin-svelte
- vike
- remix

