### PR TITLE
fix(waku): vite-ecosystem-ci script

### DIFF
--- a/tests/waku.ts
+++ b/tests/waku.ts
@@ -8,6 +8,6 @@ export async function test(options: RunOptions) {
 		branch: 'main',
 		build: 'compile',
 		beforeTest: 'pnpm playwright install',
-		test: ['pnpm run --filter waku test', 'e2e'],
+		test: 'test-vite-ecosystem-ci',
 	})
 }


### PR DESCRIPTION
This tries to use the new waku script for running the test cases in vite-ecosystem-ci! 

