### PR TITLE
fix: optional --commit flag

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -119,7 +119,7 @@ jobs:
           pnpm tsx ecosystem-ci.ts
           --branch ${{ inputs.branchName }}
           --repo ${{ inputs.repo }}
-          --commit ${{ inputs.commit }}
+          ${{ inputs.commit && '--commit ' + inputs.commit }}
           ${{ inputs.suite }}
       - id: get-ref
         if: always()
@@ -187,7 +187,7 @@ jobs:
           pnpm tsx ecosystem-ci.ts
           --branch ${{ inputs.branchName }}
           --repo ${{ inputs.repo }}
-          --commit ${{ inputs.commit }}
+          ${{ inputs.commit && '--commit ' + inputs.commit }}
           ${{ matrix.suite }}
       - id: get-ref
         if: always()


### PR DESCRIPTION
if the commit flag is empty or absent, we'd just avoid passing it so we also avoid unexpected errors! 