### PR TITLE
fix: run get-ref in root if commit is specified

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -126,7 +126,7 @@ jobs:
         run: |
           ref=${{ inputs.commit || '$(git log -1 --pretty=format:%H)' }}
           echo "ref=$ref" >> $GITHUB_OUTPUT
-        working-directory: workspace/vite
+        working-directory: ${{ inputs.commit && '.' || 'workspace/vite' }}
 
   execute-all:
     timeout-minutes: 30
@@ -194,7 +194,7 @@ jobs:
         run: |
           ref=${{ inputs.commit || '$(git log -1 --pretty=format:%H)' }}
           echo "ref=$ref" >> $GITHUB_OUTPUT
-        working-directory: workspace/vite
+        working-directory: ${{ inputs.commit && '.' || 'workspace/vite' }}
 
   update-comment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/vitejs/vite-ecosystem-ci/actions/runs/12312778835/job/34365511239#step:9:11