### PR TITLE
ci: use beta branch for analogjs

### DIFF
--- a/tests/analogjs.ts
+++ b/tests/analogjs.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'analogjs/analog',
-		branch: 'main',
+		branch: 'beta',
 		build: 'build:vite-ci',
 		test: 'test:vite-ci',
 	})


### PR DESCRIPTION
Beta is the default development branch for analogjs