### PR TITLE
feat: pkg.pr.new on main

### DIFF
--- a/discord-webhook.ts
+++ b/discord-webhook.ts
@@ -58,7 +58,8 @@ async function run() {
 
 	const refType = env.REF_TYPE
 	// vite repo is not cloned when release
-	const permRef = refType === 'release' ? undefined : await getPermanentRef()
+	const permRef =
+		refType === 'release' ? undefined : await getPermanentRef(env.REPO, env.REF)
 
 	const targetText = createTargetText(refType, env.REF, permRef, env.REPO)
 

--- a/ecosystem-ci.ts
+++ b/ecosystem-ci.ts
@@ -23,9 +23,22 @@ cli
 	.option('--commit <commit>', 'vite commit sha to use')
 	.option('--release <version>', 'vite release to use from npm registry')
 	.action(async (suites, options: CommandOptions) => {
+		if (
+			options.branch === 'main' &&
+			options.repo === 'vitejs/vite' &&
+			!options.commit
+		) {
+			const res = await fetch(
+				`https://api.github.com/repos/vitejs/vite/branches/main`,
+			)
+			const {
+				commit: { sha },
+			} = (await res.json()) as { commit: { sha: string } }
+			options.commit = sha
+		}
 		if (options.commit) {
 			const url = `https://pkg.pr.new/vite@${options.commit}`
-			//eslint-disable-next-line n/no-unsupported-features/node-builtins
+			 
 			const { status } = await fetch(url)
 			if (status === 200) {
 				options.release = url

--- a/utils.ts
+++ b/utils.ts
@@ -371,11 +371,15 @@ export async function setupViteRepo(options: Partial<RepoOptions>) {
 	}
 }
 
-export async function getPermanentRef() {
-	cd(vitePath)
+export async function getPermanentRef(repo: string, ref: string) {
 	try {
-		const ref = await $`git log -1 --pretty=format:%H`
-		return ref
+		const res = await fetch(
+			`https://api.github.com/repos/${repo}/branches/${ref}`,
+		)
+		const {
+			commit: { sha },
+		} = (await res.json()) as { commit: { sha: string } }
+		return sha
 	} catch (e) {
 		console.warn(`Failed to obtain perm ref. ${e}`)
 		return undefined


### PR DESCRIPTION
Workflow runs for the main branch do not use the pkg.pr.new build, meanwhile the main branch of the vite repo is the place where each commit gets its own pkg.pr.new build which feels a bit wasted.

So this will try to look for pkg.pr.new builds for the main branch.