### PR TITLE
fix: release type was not working

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -277,7 +277,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 		}
 
 		if (overrides.rollup !== false || overrides.esbuild === true) {
-			const viteManifest = await pacote.manifest(options.release)
+			const viteManifest = await pacote.manifest(`vite@${options.release}`)
 
 			// skip if `overrides.rollup` is `false`
 			if (overrides.rollup !== false) {


### PR DESCRIPTION
This error happens: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/12985510047/job/36210515231#step:8:27

From the example, it seems the passed argument should be like `${packageName}@${version}`.
https://www.npmjs.com/package/pacote#:~:text=pacote.manifest(%27foo%401.x%27)

