### PR TITLE
perf(waku): only install chromium

### DIFF
--- a/tests/waku.ts
+++ b/tests/waku.ts
@@ -7,7 +7,7 @@ export async function test(options: RunOptions) {
 		repo: 'dai-shi/waku',
 		branch: 'main',
 		build: 'compile',
-		beforeTest: 'pnpm playwright install',
+		beforeTest: 'pnpm playwright install chromium',
 		test: 'test-vite-ecosystem-ci',
 	})
 }


### PR DESCRIPTION
waku only uses chromium for ecosystem-ci so let's skip installing other browsers