### PR TITLE
fix: force use of node 22.14+ to avoid corepack sig errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ env:
   COREPACK_DEFAULT_TO_LATEST: 0
   COREPACK_ENABLE_AUTO_PIN: 0
   COREPACK_ENABLE_STRICT: 1
-  # see https://github.com/nodejs/corepack/issues/612#issuecomment-2631462297
-  COREPACK_INTEGRITY_KEYS: '{"npm":[{"expires":"2025-01-29T00:00:00.000Z","keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg=="},{"expires":null,"keyid":"SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEY6Ya7W++7aUPzvMTrezH6Ycx3c+HOKYCcNGybJZSCJq/fd7Qa8uuAKtdIkUQtQiEKERhAmE5lMMJhP8OkDOa2g=="}]}'
   # see https://turbo.build/repo/docs/telemetry#how-do-i-opt-out
   TURBO_TELEMETRY_DISABLED: 1
   DO_NOT_TRACK: 1
@@ -29,12 +27,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ^22.14.0
       - run: corepack enable
       - run: pnpm --version
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ^22.14.0
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: pnpm run typecheck
       - name: audit
         if: (${{ success() }} || ${{ failure() }})
-        run: pnpm audit
+        run: pnpm audit --prod --audit-level moderate
       - name: test
         if: (${{ success() }} || ${{ failure() }})
         run: pnpm test:self

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -9,8 +9,6 @@ env:
   COREPACK_DEFAULT_TO_LATEST: 0
   COREPACK_ENABLE_AUTO_PIN: 0
   COREPACK_ENABLE_STRICT: 1
-  # see https://github.com/nodejs/corepack/issues/612#issuecomment-2631462297
-  COREPACK_INTEGRITY_KEYS: '{"npm":[{"expires":"2025-01-29T00:00:00.000Z","keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg=="},{"expires":null,"keyid":"SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEY6Ya7W++7aUPzvMTrezH6Ycx3c+HOKYCcNGybJZSCJq/fd7Qa8uuAKtdIkUQtQiEKERhAmE5lMMJhP8OkDOa2g=="}]}'
   # see https://turbo.build/repo/docs/telemetry#how-do-i-opt-out
   TURBO_TELEMETRY_DISABLED: 1
   DO_NOT_TRACK: 1
@@ -112,7 +110,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ^22.14.0
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
@@ -181,7 +179,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ^22.14.0
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -9,8 +9,6 @@ env:
   COREPACK_DEFAULT_TO_LATEST: 0
   COREPACK_ENABLE_AUTO_PIN: 0
   COREPACK_ENABLE_STRICT: 1
-  # see https://github.com/nodejs/corepack/issues/612#issuecomment-2631462297
-  COREPACK_INTEGRITY_KEYS: '{"npm":[{"expires":"2025-01-29T00:00:00.000Z","keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg=="},{"expires":null,"keyid":"SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEY6Ya7W++7aUPzvMTrezH6Ycx3c+HOKYCcNGybJZSCJq/fd7Qa8uuAKtdIkUQtQiEKERhAmE5lMMJhP8OkDOa2g=="}]}'
   # see https://turbo.build/repo/docs/telemetry#how-do-i-opt-out
   TURBO_TELEMETRY_DISABLED: 1
   DO_NOT_TRACK: 1
@@ -83,7 +81,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ^22.14.0
         id: setup-node
       - uses: denoland/setup-deno@v1
         with:

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -9,8 +9,6 @@ env:
   COREPACK_DEFAULT_TO_LATEST: 0
   COREPACK_ENABLE_AUTO_PIN: 0
   COREPACK_ENABLE_STRICT: 1
-  # see https://github.com/nodejs/corepack/issues/612#issuecomment-2631462297
-  COREPACK_INTEGRITY_KEYS: '{"npm":[{"expires":"2025-01-29T00:00:00.000Z","keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg=="},{"expires":null,"keyid":"SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEY6Ya7W++7aUPzvMTrezH6Ycx3c+HOKYCcNGybJZSCJq/fd7Qa8uuAKtdIkUQtQiEKERhAmE5lMMJhP8OkDOa2g=="}]}'
   # see https://turbo.build/repo/docs/telemetry#how-do-i-opt-out
   TURBO_TELEMETRY_DISABLED: 1
   DO_NOT_TRACK: 1
@@ -86,7 +84,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ^22.14.0
         id: setup-node
       - uses: denoland/setup-deno@v1
         with:

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
       "eslint --fix"
     ]
   },
-  "packageManager": "pnpm@10.3.0",
+  "packageManager": "pnpm@10.4.1",
   "type": "module",
   "engines": {
     "node": ">=18",
@@ -66,6 +66,10 @@
   "pnpm": {
     "overrides": {
       "cross-spawn@>=7.0.0 <7.0.5": "^7.0.6"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "simple-git-hooks"
+    ]
   }
 }


### PR DESCRIPTION
the previous method of manually adding the keys to environment did not work and node 22.14 includes a newer corepack that fixes it