### PR TITLE
vike tests use playwright and it complained install was missing

### DIFF
--- a/tests/vike.ts
+++ b/tests/vike.ts
@@ -11,6 +11,7 @@ export async function test(options: RunOptions) {
 			'@vitejs/plugin-vue': true,
 		},
 		build: 'build',
+		beforeTest: 'pnpm playwright install chromium',
 		test: 'test:vite-ecosystem-ci',
 	})
 }

--- a/tests/vike.ts
+++ b/tests/vike.ts
@@ -11,7 +11,7 @@ export async function test(options: RunOptions) {
 			'@vitejs/plugin-vue': true,
 		},
 		build: 'build',
-		beforeTest: 'pnpm playwright install chromium',
+		beforeTest: 'pnpm exec playwright install chromium',
 		test: 'test:vite-ecosystem-ci',
 	})
 }


### PR DESCRIPTION
@brillout  

looks like vike tests require playwright browser install, added a script here to ensure it works. anything else that needs adaption? 

https://github.com/vitejs/vite-ecosystem-ci/actions/runs/13363207623/job/37316256667#step:8:1973