### PR TITLE
chore: remove lint and reduce amount of checks from sveltekit tests

### DIFF
--- a/tests/sveltekit.ts
+++ b/tests/sveltekit.ts
@@ -12,6 +12,9 @@ export async function test(options: RunOptions) {
 			'@sveltejs/vite-plugin-svelte-inspector': true,
 		},
 		beforeTest: 'pnpm playwright install chromium',
-		test: ['test:vite-ecosystem-ci', 'lint', 'check'],
+		test: [
+			'test:vite-ecosystem-ci',
+			'pnpm --dir packages/kit check', // only run checks for kit package, not the whole repo
+		],
 	})
 }


### PR DESCRIPTION
this helps shave some time off total suite time and reduces false positives when kit repo has failing checks on its own