### PR TITLE
ci: migrate to official app token action

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -78,11 +78,11 @@ jobs:
       comment-id: ${{ steps.create-comment.outputs.result }}
     steps:
       - id: generate-token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.PR_GITHUB_APP_ID }}
-          installation_retrieval_payload: "${{ github.repository_owner }}/vite"
-          private_key: ${{ secrets.PR_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PR_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PR_GITHUB_APP_PRIVATE_KEY }}
+          repositories: vite
       - id: create-comment
         uses: actions/github-script@v7
         with:
@@ -207,11 +207,13 @@ jobs:
     if: always()
     steps:
       - id: generate-token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.PR_GITHUB_APP_ID }}
-          installation_retrieval_payload: "${{ github.repository_owner }}/vite"
-          private_key: ${{ secrets.PR_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PR_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PR_GITHUB_APP_PRIVATE_KEY }}
+          repositories: |
+            vite
+            vite-ecosystem-ci
       - uses: actions/github-script@v7
         with:
           github-token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Migrated to https://github.com/actions/create-github-app-token from https://github.com/tibdex/github-app-token.