### PR TITLE
feat: retry manifest fetch

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -279,7 +279,15 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 		}
 
 		if (overrides.rollup !== false || overrides.esbuild === true) {
-			const viteManifest = await pacote.manifest(`vite@${options.release}`)
+			const viteManifest = await pacote.manifest(`vite@${options.release}`, {
+				retry: {
+					// enable retry with same options with pnpm (https://pnpm.io/settings#fetchretries)
+					fetchRetries: 2,
+					fetchRetryFactor: 10,
+					fetchRetryMintimeout: 10 * 1000,
+					fetchRetryMaxtimeout: 60 * 1000,
+				},
+			})
 
 			// skip if `overrides.rollup` is `false`
 			if (overrides.rollup !== false) {


### PR DESCRIPTION
Enable retries for manifest fetch since it sometimes fails.
https://github.com/vitejs/vite-ecosystem-ci/actions/runs/14505881712/job/40695132986#step:8:30

Retries are enabled by package managers already, so this aligns the behavior with them as well.
