### PR TITLE
chore: set vite-node overrides for waku and react-router

### DIFF
--- a/tests/react-router.ts
+++ b/tests/react-router.ts
@@ -9,5 +9,9 @@ export async function test(options: RunOptions) {
 		build: 'vite-ecosystem-ci:build',
 		beforeTest: 'vite-ecosystem-ci:before-test',
 		test: 'vite-ecosystem-ci:test',
+		overrides: {
+			// For Vite 7 support
+			'vite-node': '^3.2.2',
+		},
 	})
 }

--- a/tests/waku.ts
+++ b/tests/waku.ts
@@ -10,6 +10,8 @@ export async function test(options: RunOptions) {
 		beforeTest: 'pnpm playwright install chromium',
 		test: 'test-vite-ecosystem-ci',
 		overrides: {
+			// For Vite 7 support
+			'vite-node': '^3.2.2',
 			// It uses Vitest 3.2+ so we don't need to inject the overrides.
 			// If we inject overrides, the following error happens due to how waku sets overrides for the test.
 			//


### PR DESCRIPTION
To unblock https://github.com/vitejs/vite/pull/19996

These two projects use vite-node.