### PR TITLE
fix: send failure / skipped results to discord

### DIFF
--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -96,7 +96,7 @@ jobs:
           --repo ${{ inputs.repo }}
           ${{ inputs.suite }}
         id: ecosystem-ci-run
-      - if: inputs.sendDiscordReport || github.event_name != 'workflow_dispatch'
+      - if: always() && (inputs.sendDiscordReport || github.event_name != 'workflow_dispatch')
         run: pnpm tsx discord-webhook.ts
         env:
           WORKFLOW_NAME: ci-selected

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -99,7 +99,7 @@ jobs:
           --repo ${{ inputs.repo || github.event.client_payload.repo || 'vitejs/vite' }}
           ${{ matrix.suite }}
         id: ecosystem-ci-run
-      - if: inputs.sendDiscordReport || github.event_name != 'workflow_dispatch'
+      - if: always() && (inputs.sendDiscordReport || github.event_name != 'workflow_dispatch')
         run: pnpm tsx discord-webhook.ts
         env:
           WORKFLOW_NAME: ci


### PR DESCRIPTION
#388 made failure results and skipped results to be not sent to discord. This PR fixes that.

`always() && condition` seems to be the way to do this.
https://github.com/search?q=%2Falways%5C(%5C)+%26%26%2F+language%3Ayaml&type=code

Probably this is how we can understand the behavior:

> I would have expected the default value of `if: success()` to be replaced with `if: <your_condition>`, but it's actually `if: success() && <your_condition>` _unless_ your condition includes one of the status functions
> — quoted from https://github.com/actions/runner/issues/491#issuecomment-660122693
