### PR TITLE
feat: add vite-rsc

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -64,6 +64,7 @@ on:
           - vite-plugin-svelte
           - vite-plugin-vue
           - vite-plugin-cloudflare
+          - vite-rsc
           - vite-setup-catalogue
           - vitepress
           - vitest
@@ -167,6 +168,7 @@ jobs:
           - vite-plugin-svelte
           - vite-plugin-vue
           - vite-plugin-cloudflare
+          - vite-rsc
           - vite-setup-catalogue
           - vitepress
           - vitest

--- a/.github/workflows/ecosystem-ci-rolldown.yml
+++ b/.github/workflows/ecosystem-ci-rolldown.yml
@@ -73,6 +73,7 @@ jobs:
           - vite-plugin-svelte
           - vite-plugin-vue
           - vite-plugin-cloudflare
+          - vite-rsc
           - vite-setup-catalogue
           - vitepress
           - vitest

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -67,6 +67,7 @@ on:
           - vite-plugin-svelte
           - vite-plugin-vue
           - vite-plugin-cloudflare
+          - vite-rsc
           - vite-setup-catalogue
           - vitepress
           - vitest

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -76,6 +76,7 @@ jobs:
           - vite-plugin-svelte
           - vite-plugin-vue
           - vite-plugin-cloudflare
+          - vite-rsc
           - vite-setup-catalogue
           - vitepress
           - vitest

--- a/tests/vite-rsc.ts
+++ b/tests/vite-rsc.ts
@@ -1,0 +1,13 @@
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'hi-ogawa/vite-plugins',
+		branch: 'main',
+		build: 'vite-ecosystem-ci:build',
+		beforeTest: 'vite-ecosystem-ci:before-test',
+		test: 'vite-ecosystem-ci:test',
+	})
+}


### PR DESCRIPTION
This PR adds my rsc plugin https://github.com/hi-ogawa/vite-plugins/tree/main/packages/rsc to ecosystem ci.

I confirmed both vite and rolldown-vite passes locally by:

```sh
pnpm test vite-rsc
pnpm test vite-rsc --repo vitejs/rolldown-vite --branch rolldown-vite
```