### PR TITLE
fix: align execute-all matrix and workflow_dispatch option

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -151,6 +151,7 @@ jobs:
           - marko
           - nuxt
           # - nx # disabled temporarily
+          - one
           - quasar
           - qwik
           - rakkas

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -52,6 +52,7 @@ on:
           - quasar
           - qwik
           - rakkas
+          - react-router
           # - redwoodjs # disabled temporarily
           - storybook
           - sveltekit


### PR DESCRIPTION
I noticed `one` is missing in `execute-all` https://github.com/vitejs/vite-ecosystem-ci/pull/360. I asked copilot to check others and found `react-router`, so I fixed that too.

<details><summary>copilot chat log</summary>

hi-ogawa: there are two lists for `suite`. check the difference

GitHub Copilot: The `suite` option in `on.workflow_dispatch.inputs.suite.options` defines the choices available when the workflow is manually dispatched. The `suite` list in `jobs.execute-all.strategy.matrix.suite` defines the suites that run when all test suites are selected (input `suite` is `'-'`).

Here's the difference between the two lists:

**Suites present in `inputs.suite.options` but not in `jobs.execute-all.strategy.matrix.suite`:**
*   `-` (This is a special value to run all suites)
*   `hydrogen` (Commented out in `matrix.suite`: `# - hydrogen # disabled until they complete they migration back to Vite`)
*   `iles` (Commented out in `matrix.suite`: `# - iles # disabled until its CI is fixed`)
*   `nx` (Commented out in `matrix.suite`: `# - nx # disabled temporarily`)
*   `one`
*   `vite-plugin-react-pages` (Commented out in `matrix.suite`: `# - vite-plugin-react-pages # # disabled until its install setup is fixed`)
*   `redwoodjs` (Commented out in both, but present as an option)

**Suites present in `jobs.execute-all.strategy.matrix.suite` but not in `inputs.suite.options`:**
*   `react-router`

</details>