### PR TITLE
chore: remove vite-node overrides

### DIFF
--- a/tests/react-router.ts
+++ b/tests/react-router.ts
@@ -9,9 +9,5 @@ export async function test(options: RunOptions) {
 		build: 'vite-ecosystem-ci:build',
 		beforeTest: 'vite-ecosystem-ci:before-test',
 		test: 'vite-ecosystem-ci:test',
-		overrides: {
-			// For Vite 7 support
-			'vite-node': '^3.2.2',
-		},
 	})
 }

--- a/tests/waku.ts
+++ b/tests/waku.ts
@@ -10,8 +10,6 @@ export async function test(options: RunOptions) {
 		beforeTest: 'pnpm playwright install chromium',
 		test: 'test-vite-ecosystem-ci',
 		overrides: {
-			// For Vite 7 support
-			'vite-node': '^3.2.2',
 			// It uses Vitest 3.2+ so we don't need to inject the overrides.
 			// If we inject overrides, the following error happens due to how waku sets overrides for the test.
 			//


### PR DESCRIPTION
This PR reverts #393

refs https://github.com/remix-run/react-router/pull/13781, https://github.com/vanilla-extract-css/vanilla-extract/pull/1605

