### PR TITLE
fix: set overrides without special syntax to devDeps

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -555,7 +555,7 @@ export async function applyPackageOverrides(
 		const overridesWithoutSpecialSyntax = Object.fromEntries(
 			Object.entries(overrides)
 				//eslint-disable-next-line @typescript-eslint/no-unused-vars
-				.filter(([key, value]) => (value as string).includes('>')),
+				.filter(([key, value]) => !key.includes('>')),
 		)
 
 		if (!pkg.devDependencies) {


### PR DESCRIPTION
The special syntax that we want to match is `@vitejs/plugin-react-oxc>vite` in the key. The previous condition was checking the `value` and the condition was inverted.

refs https://github.com/vitejs/vite-ecosystem-ci/pull/377, https://github.com/sveltejs/svelte-ecosystem-ci/pull/35#discussion_r2191153980
