### PR TITLE
fix: respect `overrides` in `pnpm-workspace.yaml`

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -580,7 +580,7 @@ export async function applyPackageOverrides(
 				'utf-8',
 			)
 			if (/^overrides:/m.test(pnpmWorkspaceContent)) {
-				delete pkg.pnpm.overrides
+				delete pkg.pnpm.overrides // remove pnpm.overrides from package.json so that pnpm-workspace.yaml's one is used
 				const newContent = pnpmWorkspaceContent.replace(
 					/^overrides:\n/m,
 					() =>


### PR DESCRIPTION
I used `overrides` in `pnpm-workspace.yaml` in https://github.com/vitejs/vite-plugin-react/pull/557, but it's being ignored on ecosystem ci since it adds `pnpm.overrides` in `package.json`.

Also with https://github.com/vitejs/vite-plugin-react/pull/566, both vite and rolldown ci should pass. (I tested locally)