### PR TITLE
fix(one): run `clean:build` before `build`

### DIFF
--- a/tests/one.ts
+++ b/tests/one.ts
@@ -6,7 +6,7 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'onejs/one',
 		branch: 'main',
-		build: 'build',
+		build: ['clean:build', 'build'],
 		beforeTest: 'yarn playwright install chromium',
 		test: 'test:vite-ecosystem-ci',
 	})


### PR DESCRIPTION
Added `yarn clean:build` before `yarn build` so that the tests pass.
https://github.com/onejs/one/blob/15988adc83c608d1312dd05cfedff886ea8b7d4c/.github/actions/install/action.yml#L74-L76

Aiming to fix this error: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/16258417537/job/45898815760#step:7:735

cc @zetavg
