### PR TITLE
feat: override `@vitejs/plugin-rsc` on `waku` and `react-router`

### DIFF
--- a/builds/vite-plugin-react.ts
+++ b/builds/vite-plugin-react.ts
@@ -11,4 +11,5 @@ export async function build(options: RunOptions) {
 
 export const packages = {
 	'@vitejs/plugin-react': 'packages/plugin-react',
+	'@vitejs/plugin-rsc': 'packages/plugin-rsc',
 }

--- a/tests/react-router.ts
+++ b/tests/react-router.ts
@@ -9,5 +9,8 @@ export async function test(options: RunOptions) {
 		build: 'vite-ecosystem-ci:build',
 		beforeTest: 'vite-ecosystem-ci:before-test',
 		test: 'vite-ecosystem-ci:test',
+		overrides: {
+			'@vitejs/plugin-rsc': true,
+		},
 	})
 }

--- a/tests/waku.ts
+++ b/tests/waku.ts
@@ -10,6 +10,7 @@ export async function test(options: RunOptions) {
 		beforeTest: 'pnpm playwright install chromium',
 		test: 'test-vite-ecosystem-ci',
 		overrides: {
+			'@vitejs/plugin-rsc': true,
 			// It uses Vitest 3.2+ so we don't need to inject the overrides.
 			// If we inject overrides, the following error happens due to how waku sets overrides for the test.
 			//


### PR DESCRIPTION
- Related https://github.com/vitejs/vite-plugin-react/issues/645

TODO
- [x] wait for https://github.com/wakujs/waku/pull/1493
- [ ] ability to trigger from react plugin PR (later)