### PR TITLE
chore: remove rolldownViteExpectedFailureReason from waku

### DIFF
--- a/tests/waku.ts
+++ b/tests/waku.ts
@@ -19,7 +19,3 @@ export async function test(options: RunOptions) {
 		},
 	})
 }
-
-export const rolldownViteExpectedFailureReason = `
-needs to be updated on waku side
-`


### PR DESCRIPTION
Waku should now pass on rolldown-vite https://discord.com/channels/804011606160703521/1364135135447879740/1401499077656580121