### PR TITLE
add ember to ecosystem tests

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -40,6 +40,7 @@ on:
           - "-"
           - analogjs
           - astro
+          - ember
           # - histoire # disabled temporarily
           - hydrogen
           - iles
@@ -153,6 +154,7 @@ jobs:
         suite:
           - analogjs
           - astro
+          - ember
           # - histoire # disabled temporarily
           # - hydrogen # disabled until they complete they migration back to Vite
           # - iles # disabled until its CI is fixed

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -51,6 +51,7 @@ on:
         options:
           - analogjs
           - astro
+          - ember
           - histoire
           - hydrogen
           - iles

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -54,6 +54,7 @@ jobs:
         suite:
           - analogjs
           - astro
+          - ember
           # - histoire # disabled temporarily
           # - hydrogen # disabled until they complete they migration back to Vite
           # - iles # disabled until its CI is fixed

--- a/tests/ember.ts
+++ b/tests/ember.ts
@@ -1,0 +1,12 @@
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'embroider-build/embroider',
+		branch: 'main',
+		build: 'compile',
+		test: 'test',
+	})
+}


### PR DESCRIPTION
~I've opened this as a draft because it fails locally. We have started testing our support for rolldown in the ember/embroider test scenarios but there are some issues with the types that prevent our build from succeeding right now~

This is mostly working now, it's quite long because we have a lot of test scenarios 🤔 I would love to see one run on your CI of this so we can see if we can filter it down a bit