### PR TITLE
fix: disable `blockExoticSubdeps` in pnpm-workspace.yaml

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -619,6 +619,14 @@ export async function applyPackageOverrides(
 				)
 				modified = true
 			}
+			if (content.includes('blockExoticSubdeps:')) {
+				// disable with comment to avoid error on installation if ecosystem-ci overrides pull in tarball URLs
+				content = content.replace(
+					/^([ \t]*blockExoticSubdeps[ \t]*:[ \t]*\w+[^\r\n]*)$/m,
+					'# $1 -- disabled by ecosystem-ci',
+				)
+				modified = true
+			}
 			if (modified) {
 				await fs.promises.writeFile(pnpmWorkspaceFile, content, 'utf-8')
 			}


### PR DESCRIPTION
similar to #431

https://pnpm.io/settings#blockexoticsubdeps

related failure: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/23884126857/job/69643390386#step:7:1003
```
  \u2009ERR_PNPM_EXOTIC_SUBDEP\u2009 Exotic dependency "rolldown" (resolved via url) is not allowed in subdependencies when blockExoticSubdeps is enabled
  
  This error happened while installing the dependencies of vite@8.0.3
      at getFinalError (file:///home/runner/work/vite-ecosystem-ci/vite-ecosystem-ci/node_modules/.pnpm/execa@9.6.1/node_modules/execa/lib/return/final-error.js:6:9)
      at makeError (file:///home/runner/work/vite-ecosystem-ci/vite-ecosystem-ci/node_modules/.pnpm/execa@9.6.1/node_modules/execa/lib/return/result.js:108:16)
      at getAsyncResult (file:///home/runner/work/vite-ecosystem-ci/vite-ecosystem-ci/node_modules/.pnpm/execa@9.6.1/node_modules/execa/lib/methods/main-async.js:168:4)
      at handlePromise (file:///home/runner/work/vite-ecosystem-ci/vite-ecosystem-ci/node_modules/.pnpm/execa@9.6.1/node_modules/execa/lib/methods/main-async.js:151:17)
      at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
      at async $ (file:///home/runner/work/vite-ecosystem-ci/vite-ecosystem-ci/utils.ts:53:12)
      at async applyPackageOverrides (file:///home/runner/work/vite-ecosystem-ci/vite-ecosystem-ci/utils.ts:653:3)
      at async runInRepo (file:///home/runner/work/vite-ecosystem-ci/vite-ecosystem-ci/utils.ts:358:2)
      at async test (file:///home/runner/work/vite-ecosystem-ci/vite-ecosystem-ci/tests/vite-plugin-cloudflare.ts:5:2)
      at async run (file:///home/runner/work/vite-ecosystem-ci/vite-ecosystem-ci/ecosystem-ci.ts:171:2)
```
