### PR TITLE
chore: disable automated runs for ladle until its ci is fixed

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -43,7 +43,7 @@ on:
           # - histoire # disabled temporarily
           - hydrogen
           - iles
-          - ladle
+          # - ladle # disabled until its CI is fixed
           - laravel
           - marko
           - nuxt
@@ -155,7 +155,7 @@ jobs:
           # - histoire # disabled temporarily
           # - hydrogen # disabled until they complete they migration back to Vite
           # - iles # disabled until its CI is fixed
-          - ladle
+          # - ladle # disabled until its CI is fixed
           - laravel
           - marko
           - nuxt

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -57,7 +57,7 @@ jobs:
           # - histoire # disabled temporarily
           # - hydrogen # disabled until they complete they migration back to Vite
           # - iles # disabled until its CI is fixed
-          - ladle
+          # - ladle # disabled until its CI is fixed
           - laravel
           - marko
           - nuxt


### PR DESCRIPTION
last commit on ladle repo was 4 months ago and it is still on vite6.
Maintainer didn't react to ping on vite discord regarding it's CI timing out with an old version of playwright.