### PR TITLE
feat: add module-federation/vite

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -46,6 +46,7 @@ on:
           # - ladle # disabled until its CI is fixed
           - laravel
           - marko
+          - module-federation
           - nuxt
           - nx
           - one
@@ -158,6 +159,7 @@ jobs:
           # - ladle # disabled until its CI is fixed
           - laravel
           - marko
+          - module-federation
           - nuxt
           # - nx # disabled temporarily
           # - one # disabled until we figured out how to support bun

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -57,6 +57,7 @@ on:
           - ladle
           - laravel
           - marko
+          - module-federation
           - nuxt
           - nx
           # - one # disabled until we figured out how to support bun

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -60,6 +60,7 @@ jobs:
           # - ladle # disabled until its CI is fixed
           - laravel
           - marko
+          - module-federation
           - nuxt
           # - one # disabled until we figured out how to support bun
           # - nx # disabled temporarily

--- a/tests/module-federation.ts
+++ b/tests/module-federation.ts
@@ -7,6 +7,6 @@ export async function test(options: RunOptions) {
 		repo: 'module-federation/vite',
 		build: 'build',
 		beforeTest: 'pnpm playwright install chromium',
-		test: ['test', 'e2e'],
+		test: ['test', 'test:integration'],
 	})
 }

--- a/tests/module-federation.ts
+++ b/tests/module-federation.ts
@@ -5,6 +5,8 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'module-federation/vite',
-		test: 'pnpm test',
+		build: 'build',
+		beforeTest: 'pnpm playwright install chromium',
+		test: ['test', 'e2e'],
 	})
 }

--- a/tests/module-federation.ts
+++ b/tests/module-federation.ts
@@ -6,7 +6,6 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'module-federation/vite',
 		build: 'build',
-		beforeTest: 'pnpm playwright install chromium',
-		test: ['test', 'test:integration'],
+		test: ['test', 'e2e'],
 	})
 }

--- a/tests/module-federation.ts
+++ b/tests/module-federation.ts
@@ -6,6 +6,6 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'module-federation/vite',
 		build: 'build',
-		test: ['test', 'e2e'],
+		test: ['test', 'test:integration'],
 	})
 }

--- a/tests/vite-module-federation.ts
+++ b/tests/vite-module-federation.ts
@@ -1,0 +1,10 @@
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'module-federation/vite',
+		test: 'pnpm test',
+	})
+}


### PR DESCRIPTION
<img width="520" height="135" alt="Screenshot 2026-04-16 at 15 50 21" src="https://github.com/user-attachments/assets/6ed56a44-7516-482e-a37d-874dd4e4c7e4" />

Since `module-federation/vite` is the official Vite package for mfe, it makes sense to add it to this CI to prevent regressions.

Thanks for this great CI project 👏 
