### PR TITLE
fix: pin Node to 24.15 to workaround playwright bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,12 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: ^24.14.1
+          node-version: 24.15.0
       - run: corepack enable
       - run: pnpm --version
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: ^24.14.1
+          node-version: 24.15.0
           cache: "pnpm"
       - name: install
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -117,7 +117,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: ^24.14.1
+          node-version: 24.15.0
       - run: corepack enable
       - run: pnpm --version
       - run: pnpm i --frozen-lockfile
@@ -194,7 +194,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: ^24.14.1
+          node-version: 24.15.0
       - run: corepack enable
       - run: pnpm --version
       - run: pnpm i --frozen-lockfile

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -98,7 +98,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: ^24.14.1
+          node-version: 24.15.0
         id: setup-node
       - run: corepack enable
       - run: pnpm --version

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -95,7 +95,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: ^24.14.1
+          node-version: 24.15.0
         id: setup-node
       - run: corepack enable
       - run: pnpm --version


### PR DESCRIPTION
Pin Node to 24.15 to workaround playwright bug.

https://github.com/nodejs/node/issues/63487, https://github.com/max-mapper/extract-zip/issues/154, https://github.com/microsoft/playwright/issues/40998

It is fixed in playwright 1.60.0, so after all suites upgraded, we can remove this workaround.
