### PR TITLE
fix(marko): remove `beforeTest` for playwright installation

### DIFF
--- a/tests/marko.ts
+++ b/tests/marko.ts
@@ -7,7 +7,6 @@ export async function test(options: RunOptions) {
 		repo: 'marko-js/vite',
 		dir: 'marko', // default is last segment of repo, which would be vite and confusing
 		build: 'build',
-		beforeTest: 'pnpm playwright install chromium',
 		test: 'test',
 		overrides: {
 			esbuild: true,


### PR DESCRIPTION
see https://github.com/marko-js/vite/commit/451fdfaaf8e23211079625440e65b1de0f75fd4b