### PR TITLE
feat: add wxt test suite

### DIFF
--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -83,6 +83,7 @@ on:
           - vitest
           - vuepress
           - waku
+          - wxt
       sendDiscordReport:
         description: "send results to discord"
         type: boolean
@@ -103,6 +104,9 @@ jobs:
       - run: corepack enable
       - run: pnpm --version
       - run: pnpm i --frozen-lockfile
+      - name: Install Bun (wxt only)
+        if: inputs.suite == 'wxt'
+        uses: oven-sh/setup-bun@v2
       - run: >-
           node ecosystem-ci.ts
           "--$REF_TYPE" "$REF"

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -86,6 +86,7 @@ jobs:
           - vitest
           - vuepress
           - waku
+          - wxt
       fail-fast: false
     permissions:
       contents: read # to clone the repo
@@ -100,6 +101,9 @@ jobs:
       - run: corepack enable
       - run: pnpm --version
       - run: pnpm i --frozen-lockfile
+      - name: Install Bun (wxt only)
+        if: matrix.suite == 'wxt'
+        uses: oven-sh/setup-bun@v2
       - run: >-
           node ecosystem-ci.ts
           "--$REF_TYPE" "$REF"

--- a/tests/wxt.ts
+++ b/tests/wxt.ts
@@ -1,13 +1,12 @@
 import { runInRepo } from '../utils.ts'
-import type { RunOptions } from '../types.d.ts'
+import type { RunOptions } from '../types.ts'
 
 export async function test(options: RunOptions) {
-	await runInRepo({
-		...options,
-		repo: 'wxt-dev/wxt',
-		branch: 'main',
-		agent: 'bun',
-		build: 'bun run --filter wxt build',
-		test: 'bun run --filter wxt test run',
-	})
+  await runInRepo({
+    ...options,
+    repo: 'wxt-dev/wxt',
+    branch: 'main',
+    build: 'bun run --filter wxt build',
+    test: 'bun run --filter wxt test run',
+  })
 }

--- a/tests/wxt.ts
+++ b/tests/wxt.ts
@@ -1,0 +1,13 @@
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'wxt-dev/wxt',
+		branch: 'main',
+		agent: 'bun',
+		build: 'bun run --filter wxt build',
+		test: 'bun run --filter wxt test run',
+	})
+}


### PR DESCRIPTION
Adds WXT (web extension framework) to the Vite Ecosystem CI.

WXT uses Bun as its monorepo package manager, so a conditional
`oven-sh/setup-bun@v2` step is added to both workflow files, scoped
to run only when the `wxt` suite is selected.

Closes wxt-dev/wxt#241