### PR TITLE
fix: use PR_GITHUB_APP for the from-pr-rolldown token

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr-rolldown.yml
+++ b/.github/workflows/ecosystem-ci-from-pr-rolldown.yml
@@ -74,8 +74,8 @@ jobs:
       - id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          client-id: ${{ secrets.ECOSYSTEM_CI_GITHUB_APP_ID }}
-          private-key: ${{ secrets.ECOSYSTEM_CI_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PR_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PR_GITHUB_APP_PRIVATE_KEY }}
           owner: rolldown
           repositories: rolldown
           permission-issues: write # to comment on the rolldown PR
@@ -300,8 +300,8 @@ jobs:
       - id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          client-id: ${{ secrets.ECOSYSTEM_CI_GITHUB_APP_ID }}
-          private-key: ${{ secrets.ECOSYSTEM_CI_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PR_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PR_GITHUB_APP_PRIVATE_KEY }}
           owner: rolldown
           repositories: rolldown
           permission-issues: write # to update the comment on the rolldown PR


### PR DESCRIPTION
Follow-up to #484. The `ecosystem-ci-from-pr-rolldown` workflow referenced `ECOSYSTEM_CI_GITHUB_APP_ID` / `ECOSYSTEM_CI_GITHUB_APP_PRIVATE_KEY`, which are not set in this repo, so `create-github-app-token` failed with an empty `client-id` ([failed run](https://github.com/vitejs/vite-ecosystem-ci/actions/runs/28502568188/job/84483145799)).

This switches both token steps to `PR_GITHUB_APP_ID` / `PR_GITHUB_APP_PRIVATE_KEY`, the same App that `ecosystem-ci-from-pr.yml` already uses, so no new secrets are needed in this repo.

Note: this App must be installed on `rolldown/rolldown` with Issues write, since the workflow mints an `owner: rolldown` token to comment on the rolldown PR.