### PR TITLE
fix: use pull_requests permission for the from-pr-rolldown token

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr-rolldown.yml
+++ b/.github/workflows/ecosystem-ci-from-pr-rolldown.yml
@@ -78,7 +78,7 @@ jobs:
           private-key: ${{ secrets.PR_GITHUB_APP_PRIVATE_KEY }}
           owner: rolldown
           repositories: rolldown
-          permission-issues: write # to comment on the rolldown PR
+          permission-pull-requests: write # to comment on the rolldown PR
       - id: create-comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
@@ -304,7 +304,7 @@ jobs:
           private-key: ${{ secrets.PR_GITHUB_APP_PRIVATE_KEY }}
           owner: rolldown
           repositories: rolldown
-          permission-issues: write # to update the comment on the rolldown PR
+          permission-pull-requests: write # to update the comment on the rolldown PR
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:


### PR DESCRIPTION
The `ecosystem-ci-from-pr-rolldown` token was scoped with `permission-issues: write`, but a GitHub App commenting on a pull request needs the `pull_requests` permission, not `issues`. The token was minted with `issues: write` yet the comment still failed with 403 `Resource not accessible by integration`, and the response header showed `x-accepted-github-permissions: issues=write; pull_requests=write` ([failed run](https://github.com/vitejs/vite-ecosystem-ci/actions/runs/28503680709/job/84486748899)).

This switches both token steps to `permission-pull-requests: write`.

Note: the `PR_GITHUB_APP` must have Pull requests write on its `rolldown/rolldown` installation. If it does not, token generation will fail with a clear error.
