### PR TITLE
feat: scheduled rolldown ecosystem-ci digest to discord

### DIFF
--- a/.github/workflows/ecosystem-ci-rolldown.yml
+++ b/.github/workflows/ecosystem-ci-rolldown.yml
@@ -16,7 +16,7 @@ env:
   DO_NOT_TRACK: 1
 on:
   schedule:
-    - cron: "0 4 * * *" # daily 4AM UTC
+    - cron: "0 4 * * 1-5" # monday to friday 4AM UTC
   workflow_dispatch:
     inputs:
       rolldownRef:
@@ -82,13 +82,24 @@ jobs:
       - run: corepack enable
       - run: pnpm --version
       - run: pnpm i --frozen-lockfile
+      # Resolve the rolldown ref to a concrete commit up front, so the tested sha
+      # and the reported sha stay the same even if main moves during the run.
+      - id: resolve-rolldown
+        env:
+          ROLLDOWN_REF: ${{ inputs.rolldownRef || 'main' }}
+        run: |
+          key=$(curl -fsSIL "https://pkg.pr.new/rolldown@$ROLLDOWN_REF" | tr -d '\r' | awk -F': ' 'tolower($1) == "x-commit-key" { print $2 }')
+          sha="${key##*:}"
+          if [ -z "$sha" ]; then echo "could not resolve rolldown ref: $ROLLDOWN_REF"; exit 1; fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "resolved rolldown@$ROLLDOWN_REF -> $sha"
       - run: >-
           node ecosystem-ci.ts
           --rolldown-ref "$ROLLDOWN_REF"
           "$SUITE"
         id: ecosystem-ci-run
         env:
-          ROLLDOWN_REF: ${{ inputs.rolldownRef || 'main' }}
+          ROLLDOWN_REF: ${{ steps.resolve-rolldown.outputs.sha }}
           SUITE: ${{ matrix.suite }}
       - if: always() && (inputs.sendDiscordReport || github.event_name != 'workflow_dispatch')
         run: node discord-webhook.ts
@@ -97,7 +108,7 @@ jobs:
           REF_TYPE: branch
           REF: main
           REPO: vitejs/vite
-          ROLLDOWN_REF: ${{ inputs.rolldownRef || 'main' }}
+          ROLLDOWN_REF: ${{ steps.resolve-rolldown.outputs.sha }}
           SUITE: ${{ matrix.suite }}
           STATUS: ${{ job.status }}
           DISCORD_WEBHOOK_URL: ${{ secrets.ROLLDOWN_DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/ecosystem-ci-rolldown.yml
+++ b/.github/workflows/ecosystem-ci-rolldown.yml
@@ -1,0 +1,104 @@
+# integration tests for the vite ecosystem against rolldown - scheduled digest
+# vite stays on main and rolldown is overridden with its pkg.pr.new preview,
+# results are posted to the rolldown discord channel
+name: vite-ecosystem-ci-rolldown
+
+env:
+  # 7 GiB by default on GitHub, setting to 6 GiB
+  # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+  NODE_OPTIONS: --max-old-space-size=6144
+  # configure corepack to be strict but not download newer versions or change anything
+  COREPACK_DEFAULT_TO_LATEST: 0
+  COREPACK_ENABLE_AUTO_PIN: 0
+  COREPACK_ENABLE_STRICT: 1
+  # see https://turbo.build/repo/docs/telemetry#how-do-i-opt-out
+  TURBO_TELEMETRY_DISABLED: 1
+  DO_NOT_TRACK: 1
+on:
+  schedule:
+    - cron: "0 4 * * *" # daily 4AM UTC
+  workflow_dispatch:
+    inputs:
+      rolldownRef:
+        description: "rolldown ref to test from pkg.pr.new (`main` = latest)"
+        required: false
+        type: string
+        default: main
+      sendDiscordReport:
+        description: "send results to discord"
+        type: boolean
+jobs:
+  test-ecosystem:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        suite:
+          - analogjs
+          - astro
+          # - histoire # disabled temporarily
+          # - hydrogen # disabled until they complete they migration back to Vite
+          # - iles # disabled until its CI is fixed
+          # - ladle # disabled until its CI is fixed
+          - laravel
+          - marko
+          - module-federation
+          - nuxt
+          # - one # disabled until we figured out how to support bun
+          # - nx # disabled temporarily
+          - quasar
+          - qwik
+          # - rakkas # disabled temporarily
+          - react-router
+          # - redwoodjs # disabled temporarily
+          - storybook
+          - sveltekit
+          - tanstack-start
+          - unocss
+          - vike
+          - vite-environment-examples
+          - vite-plugin-pwa
+          - vite-plugin-react
+          - vite-plugin-svelte
+          - vite-plugin-vue
+          - vite-plugin-cloudflare
+          - vite-plugin-rsc
+          - vite-setup-catalogue
+          - vitepress
+          - vitest
+          - vuepress
+          - waku
+      fail-fast: false
+    permissions:
+      contents: read # to clone the repo
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24.15.0
+        id: setup-node
+      - run: corepack enable
+      - run: pnpm --version
+      - run: pnpm i --frozen-lockfile
+      - run: >-
+          node ecosystem-ci.ts
+          --rolldown-ref "$ROLLDOWN_REF"
+          "$SUITE"
+        id: ecosystem-ci-run
+        env:
+          ROLLDOWN_REF: ${{ inputs.rolldownRef || 'main' }}
+          SUITE: ${{ matrix.suite }}
+      - if: always() && (inputs.sendDiscordReport || github.event_name != 'workflow_dispatch')
+        run: node discord-webhook.ts
+        env:
+          WORKFLOW_NAME: rolldown
+          REF_TYPE: branch
+          REF: main
+          REPO: vitejs/vite
+          ROLLDOWN_REF: ${{ inputs.rolldownRef || 'main' }}
+          SUITE: ${{ matrix.suite }}
+          STATUS: ${{ job.status }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.ROLLDOWN_DISCORD_WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/discord-webhook.ts
+++ b/discord-webhook.ts
@@ -11,6 +11,7 @@ type Env = {
 	STATUS?: Status
 	DISCORD_WEBHOOK_URL?: string
 	IS_ROLLDOWN_VITE?: '1'
+	ROLLDOWN_REF?: string
 }
 
 const statusConfig = {
@@ -165,6 +166,15 @@ async function createDescription(
 	let message = `
 :scroll:\u00a0\u00a0${open}\u3000\u3000:zap:\u00a0\u00a0${targetText}
 `.trim()
+	const rolldownRef = process.env.ROLLDOWN_REF
+	if (rolldownRef) {
+		const sha = await resolveRolldownSha(rolldownRef)
+		const label = sha ? sha.slice(0, 7) : rolldownRef
+		const link = sha
+			? `https://github.com/rolldown/rolldown/commit/${sha}`
+			: `https://github.com/rolldown/rolldown/commits/${rolldownRef}`
+		message += '\n' + `:package:\u00a0\u00a0[rolldown@${label}](${link})`
+	}
 	if (expectedFailureReason) {
 		message +=
 			'\n' +
@@ -191,6 +201,18 @@ function createTargetText(
 	const refTypeText = refType === 'release' ? ' (release)' : ''
 	const link = `https://github.com/${repo}/commits/${ref}`
 	return `[${repoText}${ref}${refTypeText}](${link})`
+}
+
+async function resolveRolldownSha(ref: string) {
+	try {
+		const res = await fetch(`https://pkg.pr.new/rolldown@${ref}`, { method: 'HEAD' })
+		// the x-commit-key header looks like: rolldown:rolldown:<sha>
+		const sha = res.headers.get('x-commit-key')?.split(':').at(-1)
+		return sha || undefined
+	} catch (e) {
+		console.warn(`Failed to resolve rolldown sha for ${ref}: ${e}`)
+		return undefined
+	}
 }
 
 run().catch((e) => {

--- a/discord-webhook.ts
+++ b/discord-webhook.ts
@@ -168,12 +168,8 @@ async function createDescription(
 `.trim()
 	const rolldownRef = process.env.ROLLDOWN_REF
 	if (rolldownRef) {
-		const sha = await resolveRolldownSha(rolldownRef)
-		const label = sha ? sha.slice(0, 7) : rolldownRef
-		const link = sha
-			? `https://github.com/rolldown/rolldown/commit/${sha}`
-			: `https://github.com/rolldown/rolldown/commits/${rolldownRef}`
-		message += '\n' + `:package:\u00a0\u00a0[rolldown@${label}](${link})`
+		const link = `https://github.com/rolldown/rolldown/commit/${rolldownRef}`
+		message += '\n' + `:package:\u00a0\u00a0[rolldown@${rolldownRef.slice(0, 7)}](${link})`
 	}
 	if (expectedFailureReason) {
 		message +=
@@ -201,18 +197,6 @@ function createTargetText(
 	const refTypeText = refType === 'release' ? ' (release)' : ''
 	const link = `https://github.com/${repo}/commits/${ref}`
 	return `[${repoText}${ref}${refTypeText}](${link})`
-}
-
-async function resolveRolldownSha(ref: string) {
-	try {
-		const res = await fetch(`https://pkg.pr.new/rolldown@${ref}`, { method: 'HEAD' })
-		// the x-commit-key header looks like: rolldown:rolldown:<sha>
-		const sha = res.headers.get('x-commit-key')?.split(':').at(-1)
-		return sha || undefined
-	} catch (e) {
-		console.warn(`Failed to resolve rolldown sha for ${ref}: ${e}`)
-		return undefined
-	}
 }
 
 run().catch((e) => {


### PR DESCRIPTION
Adds a run that tests the Vite ecosystem against rolldown's latest main on weekdays and reports each suite to a rolldown Discord channel, mirroring the existing vite digest.

### Changes

- New workflow `ecosystem-ci-rolldown.yml`. Runs on a Monday to Friday cron and is also manually dispatchable with an explicit `rolldownRef` (default `main`). A first step resolves the ref to a concrete commit sha from the `pkg.pr.new` `x-commit-key` header, and both the test run (`--rolldown-ref <sha>`) and the Discord report use that pinned sha, so the tested commit and the reported commit stay the same even if main moves during the run. Vite stays on `main`, only rolldown changes.
- `discord-webhook.ts`. When `ROLLDOWN_REF` is set, the embed gains a `rolldown@<sha>` line linking to that commit. Existing vite runs do not set `ROLLDOWN_REF`, so their messages are unchanged.

### Message preview

> **✅ vitest**
>
> 📜 [Open](run-url)　　⚡ [main (a1b2c3d)](vite-commit)
> 📦 [rolldown@2e905f8](https://github.com/rolldown/rolldown/commit/2e905f8...)

### Setup required

Add a `ROLLDOWN_DISCORD_WEBHOOK_URL` secret set to the rolldown Discord channel webhook. When it is unset, `discord-webhook.ts` skips silently, so merging this does not break anything.
