### PR TITLE
fix: pack local overrides into tarballs for yarn repos

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import fs from 'fs'
+import os from 'os'
 import { fileURLToPath, pathToFileURL } from 'url'
 import { execaCommand } from 'execa'
 import type {
@@ -606,9 +607,23 @@ export async function applyPackageOverrides(
 			await fs.promises.writeFile(pnpmWorkspaceFile, content, 'utf-8')
 		}
 	} else if (pm === 'yarn') {
+		// Yarn's `file:` protocol copies the referenced directory verbatim, ignoring the
+		// package's `files` field. So vite's `src` (excluded from the published package)
+		// gets copied too, and it contains test-fixture symlinks pointing to directories
+		// that yarn's node-modules linker then fails to clone (EISDIR) when it creates a
+		// per-peer-context duplicate of vite. Packing each local override into a tarball
+		// applies the `files` field, so only the real published files are shipped and the
+		// problematic fixtures never enter the install.
+		const yarnOverrides: Record<string, string> = {}
+		for (const [name, value] of Object.entries(overrides)) {
+			yarnOverrides[name] =
+				typeof value === 'string' && value.startsWith('file:')
+					? `file:${await packLocalOverride(value.slice('file:'.length))}`
+					: (value as string)
+		}
 		pkg.resolutions = {
 			...pkg.resolutions,
-			...overrides,
+			...yarnOverrides,
 		}
 	} else if (pm === 'npm') {
 		pkg.overrides = {
@@ -638,6 +653,20 @@ export async function applyPackageOverrides(
 	} else if (pm === 'npm') {
 		await $`npm install`
 	}
+}
+
+// Pack a local package directory into a tarball (honoring its `files` field) and
+// return the tarball path. `npm pack` only reads the directory (writing the tarball
+// elsewhere), so the vite checkout is left untouched. `--ignore-scripts` skips
+// lifecycle scripts since the package is already built by `buildVite`.
+async function packLocalOverride(packageDir: string): Promise<string> {
+	const destDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vite-ecosystem-ci-pack-'))
+	const { stdout } = await execaCommand(
+		`npm pack --json --ignore-scripts --pack-destination ${destDir}`,
+		{ cwd: packageDir, env },
+	)
+	const filename = JSON.parse(stdout)[0].filename
+	return path.join(destDir, filename)
 }
 
 export function dirnameFrom(url: string) {


### PR DESCRIPTION
Storybook is currently failing with
```
YN0001: Error: While cloning /home/runner/work/vite-ecosystem-ci/vite-ecosystem-ci/workspace/storybook/storybook/node_modules/vite -> /home/runner/work/vite-ecosystem-ci/vite-ecosystem-ci/workspace/storybook/storybook/code/frameworks/angular/node_modules/vite EISDIR: illegal operation on a directory, copyfile '/home/runner/work/vite-ecosystem-ci/vite-ecosystem-ci/workspace/storybook/storybook/node_modules/vite/src/node/__tests__/fixtures/config/entry/node_modules/@vite/test-config-plugin-module-condition' -> '/home/runner/work/vite-ecosystem-ci/vite-ecosystem-ci/workspace/storybook/storybook/code/frameworks/angular/node_modules/vite/src/node/__tests__/fixtures/config/entry/node_modules/@vite/test-config-plugin-module-condition'
```
https://github.com/vitejs/vite-ecosystem-ci/actions/runs/28564815109/job/84689804268#step:7:1014

It seems this is yarn's bug, but I failed to trim it down. This PR adds a workaround for that.

### Chain of causes

- Yarn's `file:` protocol copies the referenced directory verbatim, ignoring the package's `files` field. So the local vite override drags in `vite/src`, including a test fixture that is a symlink pointing to a directory (`…/entry/node_modules/@vite/test-config-plugin-module-condition -> ../../../plugin-module-condition`). That fixture is created by vite's own `pnpm install` (the `packages/**/__tests__/**` workspace glob + a `link:` dep) and has existed since early 2025.
- vite declares ~12 (optional) `peerDependencies`. Yarn's node-modules linker therefore materializes a duplicate copy of vite wherever a consumer subtree resolves those peers differently.
- Materializing that duplicate goes through yarn's clone routine, which copies with `fs.copyFile` and does not special-case symlinks (it only branches directory-vs-file). `copyFile` dereferences the symlink; copying a directory via `copyFile` throws `EISDIR`.

### Why it surfaced now

nothing in vite's fixtures changed. Between two ecosystem-ci runs the dependency graph shifted (vite `8.1.0-beta.0` → `8.1.2`, storybook `next` `alpha.7` → `alpha.9`) enough that yarn started creating the duplicate vite under the Angular framework.

### Fix in this PR

for yarn repos, pack each local `file:` override with `npm pack` (which honors `files`) and point the resolution at the resulting tarball. Only the real published files are shipped, so `vite/src` never enter the install. `npm pack` only reads the checkout and writes the tarball to a temp dir, so the vite working tree is untouched.

### Alternatives considered

- `portal:` instead of `file:`: avoids the copy, but drags vite's resolved deps into consumers (version conflicts) and makes yarn try to run build scripts against vite's pnpm-managed dir (`findPackageLocation` failure).
- Force a single vite instance by pinning vite's deps: doesn't work. the duplicate is driven by vite's optional `peerDependencies`, not its regular deps, so yarn keeps creating per-context copies. The fix has to make the copy safe, not prevent it.
