### PR TITLE
fix: use `client-id` instead of deprecated `app-id` for GitHub App token

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr-rolldown.yml
+++ b/.github/workflows/ecosystem-ci-from-pr-rolldown.yml
@@ -74,7 +74,7 @@ jobs:
       - id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ secrets.PR_GITHUB_APP_ID }}
+          client-id: ${{ secrets.PR_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PR_GITHUB_APP_PRIVATE_KEY }}
           owner: rolldown
           repositories: rolldown
@@ -300,7 +300,7 @@ jobs:
       - id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ secrets.PR_GITHUB_APP_ID }}
+          client-id: ${{ secrets.PR_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PR_GITHUB_APP_PRIVATE_KEY }}
           owner: rolldown
           repositories: rolldown

--- a/.github/workflows/ecosystem-ci-from-pr-rolldown.yml
+++ b/.github/workflows/ecosystem-ci-from-pr-rolldown.yml
@@ -74,7 +74,7 @@ jobs:
       - id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          client-id: ${{ secrets.PR_GITHUB_APP_CLIENT_ID }}
+          client-id: ${{ vars.PR_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PR_GITHUB_APP_PRIVATE_KEY }}
           owner: rolldown
           repositories: rolldown
@@ -300,7 +300,7 @@ jobs:
       - id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          client-id: ${{ secrets.PR_GITHUB_APP_CLIENT_ID }}
+          client-id: ${{ vars.PR_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PR_GITHUB_APP_PRIVATE_KEY }}
           owner: rolldown
           repositories: rolldown

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -82,7 +82,7 @@ jobs:
       - id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ secrets.PR_GITHUB_APP_ID }}
+          client-id: ${{ secrets.PR_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PR_GITHUB_APP_PRIVATE_KEY }}
           repositories: vite
       - id: create-comment
@@ -227,7 +227,7 @@ jobs:
       - id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ secrets.PR_GITHUB_APP_ID }}
+          client-id: ${{ secrets.PR_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PR_GITHUB_APP_PRIVATE_KEY }}
           repositories: |
             vite

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -82,7 +82,7 @@ jobs:
       - id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          client-id: ${{ secrets.PR_GITHUB_APP_CLIENT_ID }}
+          client-id: ${{ vars.PR_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PR_GITHUB_APP_PRIVATE_KEY }}
           repositories: vite
       - id: create-comment
@@ -227,7 +227,7 @@ jobs:
       - id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          client-id: ${{ secrets.PR_GITHUB_APP_CLIENT_ID }}
+          client-id: ${{ vars.PR_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PR_GITHUB_APP_PRIVATE_KEY }}
           repositories: |
             vite

--- a/docs/pr-comment-setup.md
+++ b/docs/pr-comment-setup.md
@@ -19,7 +19,7 @@
   - `ECOSYSTEM_CI_GITHUB_APP_ID`: ID of the created GitHub App
   - `ECOSYSTEM_CI_GITHUB_APP_PRIVATE_KEY`: the content of the private key of the created GitHub App
 - vitejs/vite-ecosystem-ci
-  - `PR_GITHUB_APP_ID`: ID of the created GitHub App
+  - `PR_GITHUB_APP_CLIENT_ID`: Client ID of the created GitHub App
   - `PR_GITHUB_APP_PRIVATE_KEY`: the content of the private key of the created GitHub App
 
 ## (3) Adding workflows to vitejs/vite

--- a/docs/pr-comment-setup.md
+++ b/docs/pr-comment-setup.md
@@ -13,14 +13,14 @@
 1. Generate a private key. It can be generated on the same page with the App ID. The key will be downloaded when you generate it.
    ![GitHub App private key](github_app_private_key.png)
 
-## (2) Adding secrets to vitejs/vite and vitejs/vite-ecosystem-ci
+## (2) Adding secrets / vars to vitejs/vite and vitejs/vite-ecosystem-ci
 
 - vitejs/vite
-  - `ECOSYSTEM_CI_GITHUB_APP_ID`: ID of the created GitHub App
-  - `ECOSYSTEM_CI_GITHUB_APP_PRIVATE_KEY`: the content of the private key of the created GitHub App
+  - var `ECOSYSTEM_CI_GITHUB_APP_CLIENT_ID`: ID of the created GitHub App
+  - secret `ECOSYSTEM_CI_GITHUB_APP_PRIVATE_KEY`: the content of the private key of the created GitHub App
 - vitejs/vite-ecosystem-ci
-  - `PR_GITHUB_APP_CLIENT_ID`: Client ID of the created GitHub App
-  - `PR_GITHUB_APP_PRIVATE_KEY`: the content of the private key of the created GitHub App
+  - var `PR_GITHUB_APP_CLIENT_ID`: Client ID of the created GitHub App
+  - secret `PR_GITHUB_APP_PRIVATE_KEY`: the content of the private key of the created GitHub App
 
 ## (3) Adding workflows to vitejs/vite
 


### PR DESCRIPTION
`actions/create-github-app-token` has deprecated the `app-id` input in favor of `client-id`. This PR switches the PR-comment token steps to `client-id`.

### Changes

- Replace `app-id` with `client-id` in `.github/workflows/ecosystem-ci-from-pr.yml` and `.github/workflows/ecosystem-ci-from-pr-rolldown.yml`.
- Rename the secret `PR_GITHUB_APP_ID` → `PR_GITHUB_APP_CLIENT_ID` (the value is now the App's **Client ID**, not the numeric App ID).
- Update `docs/pr-comment-setup.md` accordingly.

### ⚠️ Action required before merging

Add a new secret in `vitejs/vite-ecosystem-ci`: `PR_GITHUB_APP_CLIENT_ID` — the GitHub App's **Client ID** (e.g. `Iv23xxxx`, found on the App's settings page). Without this secret, the token generation step will fail.
