### PR TITLE
fix(nuxt): update command to use vitest projects

### DIFF
--- a/tests/nuxt.ts
+++ b/tests/nuxt.ts
@@ -11,6 +11,6 @@ export async function test(options: RunOptions) {
 		},
 		build: ['dev:prepare', 'build'],
 		beforeTest: 'pnpm playwright-core install',
-		test: ['test:fixtures', 'test:fixtures:dev', 'test:types'],
+		test: ['test:prepare', 'pnpm vitest run --project fixtures:vite-*', 'test:types'],
 	})
 }


### PR DESCRIPTION
spotted in https://github.com/vitejs/vite-ecosystem-ci/actions/runs/29396303584/job/87290475564 that we were running webpack tests in the vite ecosystem ci 🤦 

this likely started when we moved nuxt to use vitest projects, rather than using matrix format in CI