### PR TITLE
chore: add explicit node types and migrate built-in imports to node: prefix

### DIFF
--- a/ecosystem-ci.ts
+++ b/ecosystem-ci.ts
@@ -1,6 +1,6 @@
-import fs from 'fs'
-import path from 'path'
-import process from 'process'
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
 import { cac } from 'cac'
 
 import {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
 		"lib": ["esnext"],
 		"sourceMap": true,
 		"erasableSyntaxOnly": true,
-		"verbatimModuleSyntax": true
+		"verbatimModuleSyntax": true,
+		"types": ["node"]
 	}
 }

--- a/utils.ts
+++ b/utils.ts
@@ -1,6 +1,6 @@
-import path from 'path'
-import fs from 'fs'
-import os from 'os'
+import path from 'node:path'
+import fs from 'node:fs'
+import os from 'node:os'
 import { fileURLToPath, pathToFileURL } from 'url'
 import { execaCommand } from 'execa'
 import type {


### PR DESCRIPTION
Although the project currently type-checks, that behavior is incidental: [utils.ts](https://github.com/vitejs/vite-ecosystem-ci/blob/ff344dc60600df7ef33c95cdf51f3c3e4aeb1c34/utils.ts#L18) imports pacote, and index.d.ts includes `/// <reference types="node" />`, which indirectly pulls Node types into the program. 

In TypeScript 6, the default types scope is empty, so relying on transitive inclusion like this is fragile and may break after dependency changes; adding explicit Node types makes built-in module and global Node typings deterministic, aligns with TS6 migration guidance, and keeps local/CI behavior stable across upgrades.

https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/#types-now-defaults-to:~:text=This%20will%20affect%20many%20projects.%20You%20will%20likely%20need%20to%20add%20%22types%22%3A%20%5B%22node%22%5D%20or%20a%20few%20others%3A