### PR TITLE
ci: skip workflows on forks

### DIFF
--- a/.github/workflows/ecosystem-ci-rolldown.yml
+++ b/.github/workflows/ecosystem-ci-rolldown.yml
@@ -29,6 +29,7 @@ on:
         type: boolean
 jobs:
   test-ecosystem:
+    if: github.repository == 'vitejs/vite-ecosystem-ci'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -47,6 +47,7 @@ on:
     types: [ecosystem-ci]
 jobs:
   test-ecosystem:
+    if: github.repository == 'vitejs/vite-ecosystem-ci'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Preventing certain scheduled actions from running in the forked repository often results in failure emails.