### PR TITLE
feat: add vinext

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr-rolldown.yml
+++ b/.github/workflows/ecosystem-ci-from-pr-rolldown.yml
@@ -52,6 +52,7 @@ on:
           - tanstack-start
           - unocss
           - vike
+          - vinext
           - vite-environment-examples
           - vite-plugin-pwa
           - vite-plugin-react
@@ -151,6 +152,7 @@ jobs:
           - tanstack-start
           - unocss
           - vike
+          - vinext
           - vite-environment-examples
           - vite-plugin-pwa
           - vite-plugin-react

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -60,6 +60,7 @@ on:
           - tanstack-start
           - unocss
           - vike
+          - vinext
           - vite-environment-examples
           - vite-plugin-pwa
           - vite-plugin-react
@@ -176,6 +177,7 @@ jobs:
           - tanstack-start
           - unocss
           - vike
+          - vinext
           - vite-environment-examples
           - vite-plugin-pwa
           - vite-plugin-react

--- a/.github/workflows/ecosystem-ci-rolldown.yml
+++ b/.github/workflows/ecosystem-ci-rolldown.yml
@@ -57,6 +57,7 @@ jobs:
           - tanstack-start
           - unocss
           - vike
+          - vinext
           - vite-environment-examples
           - vite-plugin-pwa
           - vite-plugin-react

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -71,6 +71,7 @@ on:
           - tanstack-start
           - unocss
           - vike
+          - vinext
           - vite-environment-examples
           - vite-plugin-pwa
           - vite-plugin-react

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -75,6 +75,7 @@ jobs:
           - tanstack-start
           - unocss
           - vike
+          - vinext
           - vite-environment-examples
           - vite-plugin-pwa
           - vite-plugin-react

--- a/tests/vinext.ts
+++ b/tests/vinext.ts
@@ -1,4 +1,4 @@
-import { $, runInRepo } from '../utils.ts'
+import { runInRepo } from '../utils.ts'
 import type { RunOptions } from '../types.d.ts'
 
 export async function test(options: RunOptions) {
@@ -6,7 +6,7 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'cloudflare/vinext',
 		branch: 'main',
-		beforeInstall: async () => $`pnpm config set frozen-lockfile false --location project`,
+		beforeInstall: 'vite-ecosystem-ci:before-install',
 		build: 'vite-ecosystem-ci:build',
 		test: 'vite-ecosystem-ci:test',
 		overrides: {

--- a/tests/vinext.ts
+++ b/tests/vinext.ts
@@ -1,0 +1,16 @@
+import { $, runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.d.ts'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'cloudflare/vinext',
+		branch: 'main',
+		beforeInstall: async () => $`pnpm config set frozen-lockfile false --location project`,
+		build: 'vite-ecosystem-ci:build',
+		test: 'vite-ecosystem-ci:test',
+		overrides: {
+			'@vitejs/plugin-rsc': true,
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- add a vinext suite tracking cloudflare/vinext main
- run vinext's focused Vite ecosystem build and test scripts
- test against @vitejs/plugin-rsc built from the latest vite-plugin-react main
- disable vinext's project-level frozen lockfile setting only in ecosystem-ci's disposable checkout before applying overrides
- include vinext in scheduled, selected, Vite PR, and Rolldown workflow matrices

The vinext entry points landed in cloudflare/vinext#2833.

## Validation

- pnpm format
- pnpm lint
- pnpm typecheck
- [vinext selected ecosystem suite with latest plugin-rsc](https://github.com/james-elicx/vite-ecosystem-ci/actions/runs/31367239248)