### PR TITLE
fix: use `config.*` cli arg for pnpm

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -668,7 +668,7 @@ export async function applyPackageOverrides(
 
 	// use of `ni` command here could cause lockfile violation errors so fall back to native commands that avoid these
 	if (pm === 'pnpm') {
-		await $`pnpm install --prefer-frozen-lockfile --strict-peer-dependencies false`
+		await $`pnpm install --prefer-frozen-lockfile --config.strict-peer-dependencies=false`
 	} else if (pm === 'yarn') {
 		await $`yarn install`
 	} else if (pm === 'npm') {


### PR DESCRIPTION
Fixes this error:
```
  error: unexpected argument '--prefer-frozen-lockfile' found
  
    tip: to pass '--prefer-frozen-lockfile' as a value, use '-- --prefer-frozen-lockfile'
  
  Usage: pnpm add [OPTIONS] <PACKAGE_NAMES>...
  
  For more information, try '--help'.
  file:///home/runner/work/vite-ecosystem-ci/vite-ecosystem-ci/node_modules/.pnpm/execa@10.0.1/node_modules/execa/lib/return/final-error.js:6
  	return new ErrorClass(message, options);
  	       ^
  
  ExecaError: Command failed with exit code 2: pnpm install --prefer-frozen-lockfile --strict-peer-dependencies false
  
  error: unexpected argument '--prefer-frozen-lockfile' found
  
    tip: to pass '--prefer-frozen-lockfile' as a value, use '-- --prefer-frozen-lockfile'
  
  Usage: pnpm add [OPTIONS] <PACKAGE_NAMES>...
```
https://github.com/vitejs/vite-ecosystem-ci/actions/runs/33192706852/job/98921964437#step:7:1604