### PR TITLE
fix: use `pnpm --filter vite ls` instead of `pnpm ls` in `packages/vite`

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -756,8 +756,8 @@ async function getVitePackageInfo(vitePath: string): Promise<PackageInfo> {
 	try {
 		// run in vite dir to avoid package manager mismatch error from corepack
 		const current = cwd
-		cd(`${vitePath}/packages/vite`)
-		const lsOutput = $`pnpm ls --json`
+		cd(vitePath)
+		const lsOutput = $`pnpm --filter vite ls --json`
 		cd(current)
 		const lsParsed = JSON.parse(await lsOutput)
 		return lsParsed[0] as PackageInfo


### PR DESCRIPTION
fix for the change described in https://github.com/pnpm/pnpm/issues/14494

This fixes failures like https://github.com/vitejs/vite-ecosystem-ci/actions/runs/33612752815
