### PR TITLE
fix: merge inline pnpm workspace overrides

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -572,14 +572,13 @@ export async function applyPackageOverrides(
 				const output = await $`pnpm config list --json --location project`
 				const currentOverrides = JSON.parse(output).overrides
 				const mergedOverrides = { ...currentOverrides, ...overrides }
-				// replace all indented lines in `overrides` section
-				content = content.replace(
-					/^overrides:\n((?:[ \t]+.+\n)*)/m,
-					() =>
-						`overrides:\n${Object.entries(mergedOverrides)
-							.map(([name, version]) => `  ${JSON.stringify(name)}: ${JSON.stringify(version)}\n`)
-							.join('')}`,
-				)
+				const serializedOverrides = `overrides:\n${Object.entries(mergedOverrides)
+					.map(([name, version]) => `  ${JSON.stringify(name)}: ${JSON.stringify(version)}\n`)
+					.join('')}`
+				// replace either an inline mapping or all indented lines in the section
+				content = /^overrides:[ \t]*\S[^\r\n]*$/m.test(content)
+					? content.replace(/^overrides:[^\r\n]*\r?\n?/m, serializedOverrides)
+					: content.replace(/^overrides:\r?\n((?:[ \t]+.+\r?\n)*)/m, serializedOverrides)
 			} else {
 				content += `\noverrides:\n${Object.entries(overrides)
 					.map(([name, version]) => `  ${JSON.stringify(name)}: ${JSON.stringify(version)}\n`)

--- a/utils.ts
+++ b/utils.ts
@@ -576,9 +576,10 @@ export async function applyPackageOverrides(
 					.map(([name, version]) => `  ${JSON.stringify(name)}: ${JSON.stringify(version)}\n`)
 					.join('')}`
 				// replace either an inline mapping or all indented lines in the section
-				content = /^overrides:[ \t]*\S[^\r\n]*$/m.test(content)
-					? content.replace(/^overrides:[^\r\n]*\r?\n?/m, serializedOverrides)
-					: content.replace(/^overrides:\r?\n((?:[ \t]+.+\r?\n)*)/m, serializedOverrides)
+				content = content.replace(
+					/^overrides:(?:[ \t]*\S[^\r\n]*\r?\n?|[ \t]*\r?\n(?:[ \t]+.+\r?\n)*)/m,
+					serializedOverrides,
+				)
 			} else {
 				content += `\noverrides:\n${Object.entries(overrides)
 					.map(([name, version]) => `  ${JSON.stringify(name)}: ${JSON.stringify(version)}\n`)

--- a/utils.ts
+++ b/utils.ts
@@ -572,13 +572,12 @@ export async function applyPackageOverrides(
 				const output = await $`pnpm config list --json --location project`
 				const currentOverrides = JSON.parse(output).overrides
 				const mergedOverrides = { ...currentOverrides, ...overrides }
-				const serializedOverrides = `overrides:\n${Object.entries(mergedOverrides)
-					.map(([name, version]) => `  ${JSON.stringify(name)}: ${JSON.stringify(version)}\n`)
-					.join('')}`
 				// replace either an inline mapping or all indented lines in the section
 				content = content.replace(
 					/^overrides:(?:[ \t]*\S[^\r\n]*\r?\n?|[ \t]*\r?\n(?:[ \t]+.+\r?\n)*)/m,
-					serializedOverrides,
+					`overrides:\n${Object.entries(mergedOverrides)
+						.map(([name, version]) => `  ${JSON.stringify(name)}: ${JSON.stringify(version)}\n`)
+						.join('')}`,
 				)
 			} else {
 				content += `\noverrides:\n${Object.entries(overrides)

--- a/utils.ts
+++ b/utils.ts
@@ -572,7 +572,7 @@ export async function applyPackageOverrides(
 				const output = await $`pnpm config list --json --location project`
 				const currentOverrides = JSON.parse(output).overrides
 				const mergedOverrides = { ...currentOverrides, ...overrides }
-				// replace either an inline mapping or all indented lines in the section
+				// replace either an inline mapping or all indented lines in the `overrides` section
 				content = content.replace(
 					/^overrides:(?:[ \t]*\S[^\r\n]*\r?\n?|[ \t]*\r?\n(?:[ \t]+.+\r?\n)*)/m,
 					`overrides:\n${Object.entries(mergedOverrides)


### PR DESCRIPTION
`applyPackageOverrides` detected inline pnpm workspace mappings such as `overrides: {}`, but its multiline-only replacement left them unchanged. This prevented local overrides from applying workspace-wide and caused SvelteKit and Vitest to load different Vite instances.